### PR TITLE
Early failure message when backend is down.

### DIFF
--- a/src/auth/AxiosJwtAuthService.js
+++ b/src/auth/AxiosJwtAuthService.js
@@ -18,6 +18,7 @@ const optionsPropTypes = {
     REFRESH_ACCESS_TOKEN_ENDPOINT: PropTypes.string.isRequired,
     ACCESS_TOKEN_COOKIE_NAME: PropTypes.string.isRequired,
     CSRF_TOKEN_API_PATH: PropTypes.string.isRequired,
+    SHOULD_RETRY: PropTypes.bool.isRequired,
   }).isRequired,
   loggingService: PropTypes.shape({
     logError: PropTypes.func.isRequired,
@@ -58,6 +59,7 @@ class AxiosJwtAuthService {
       this.loggingService,
       this.config.ACCESS_TOKEN_COOKIE_NAME,
       this.config.REFRESH_ACCESS_TOKEN_ENDPOINT,
+      this.config.SHOULD_RETRY,
     );
     this.csrfTokenService = new AxiosCsrfTokenService(this.config.CSRF_TOKEN_API_PATH);
     this.authenticatedHttpClient = this.addAuthenticationToHttpClient(axios.create());

--- a/src/config.js
+++ b/src/config.js
@@ -56,6 +56,7 @@ let config = {
   LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
   LOGO_WHITE_URL: process.env.LOGO_WHITE_URL,
   FAVICON_URL: process.env.FAVICON_URL,
+  SHOULD_RETRY: process.env.SHOULD_RETRY,
 };
 
 /**


### PR DESCRIPTION
WIP:
This patch would enable MFE to fail early just in
case of backend (LMS) is down and it want to show some user
facing page instead of showing a blank page.

VAN-129