### PR TITLE
feat: make auth service overridable:

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -23,3 +23,4 @@ LOGO_TRADEMARK_URL=https://edx-cdn.org/v3/default/logo-trademark.svg
 LOGO_WHITE_URL=https://edx-cdn.org/v3/default/logo-white.svg
 FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
 IGNORED_ERROR_REGEX=
+FAKE_AUTH=false

--- a/README.md
+++ b/README.md
@@ -137,3 +137,5 @@ NOTE: As of this writing, i18n is _not_ configurable.  The `initialize()` functi
 When making changes to frontend-platform, be sure to manually run the included example app located in `./example`. The example app includes 2 routes to test for both unauthenticated and authenticated users. To start the example app, run `npm start` from the root directory.
 
 If you want to test changes to frontend-platform against a micro-frontend locally, follow the directions here: https://github.com/edx/frontend-build#local-module-configuration-for-webpack
+
+To be able to run or test _without the need of having LMS in the background_. You can set the `FAKE_AUTH` env variable to `true`, in the `env.development` file. This will override the auth service flow, so there would be no need to run a backend service. 

--- a/src/config.js
+++ b/src/config.js
@@ -67,6 +67,7 @@ let config = {
   LOGO_TRADEMARK_URL: process.env.LOGO_TRADEMARK_URL,
   LOGO_WHITE_URL: process.env.LOGO_WHITE_URL,
   FAVICON_URL: process.env.FAVICON_URL,
+  FAKE_AUTH: process.env.FAKE_AUTH === 'false',
 };
 
 /**

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -108,12 +108,17 @@ export async function initError(error) {
  * - Optionally redirecting to login if the application requires an authenticated user.
  * - Optionally loading additional user information via the application's user account data
  * endpoint.
+ * - When FAKE_AUTH is set to true, the function will mock an authticanted user
+ * (can be useful to run MFE without having to start LMS/CMS)
  *
  * @param {boolean} requireUser Whether or not we should redirect to login if a user is not
  * authenticated.
  * @param {boolean} hydrateUser Whether or not we should fetch additional user account data.
  */
 export async function auth(requireUser, hydrateUser) {
+  if (getConfig().FAKE_AUTH) {
+    return;
+  }
   if (requireUser) {
     await ensureAuthenticatedUser(global.location.href);
   } else {


### PR DESCRIPTION
- Add a new .env variable FAKE_AUTH
- One set to true, auth will ignored
- One set to anything else, it should as expected
- The deafult value of FAKE_AUTH is false
- Add description in the readme

**Description:**

Make it possible to override the auth service. So we would be able to test/run the frontend apps without the need to run the **heavy lms**. 

Also not running the lms, means less energy is consumped by the machine, which means battery stays longer. And lastly it's better for environment to consume less energy. 

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
