### PR TITLE
fix: moving the README docs link to the new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Overview
 
-See the [GitHub Pages site for the complete documentation](https://edx.github.io/frontend-platform/).
+See the [GitHub Pages site for the complete documentation](https://openedx.github.io/frontend-platform/).
 
 frontend-platform is a modest application framework for Open edX micro-frontend applications and their supporting libraries. It provides a number of foundational services that all Open edX micro-frontends should have:
 


### PR DESCRIPTION
Intentionally labeling this a "fix" to generate a new release, now that the repo has been moved from the edx org to the openedx org.

**Description:**

Describe what this pull request changes, and why. Include implications for people using this change.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
