### PR TITLE
docs: ADR to make redux dependency optional

### DIFF
--- a/docs/decisions/0006-make-redux-deps-optional.rst
+++ b/docs/decisions/0006-make-redux-deps-optional.rst
@@ -11,9 +11,12 @@ Context
 
 Some consumers of frontend-platform, such as frontend-app-learner-portal-enterprise, no longer use redux or react-redux.
 However, they are still required to install these dependencies due to the usage of react-redux in AppProvider, and the fact that
-react-redux and redux are peerDependencies.
+react-redux and redux are peerDependencies. To be precise, the OptionalReduxProvider used by AppProvider is what uses the
+react-redux Provider in case a store prop is passed to AppProvider.
 
-This means there is extra overhead and confusion in such projects, when they are not leveraging the `store` feature of AppProvider.
+However, it's only optional from a code perspecitve, it's not optional from a dependency perspective right now.
+
+This means there is extra overhead and confusion on seeing 'redux' and 'react-redux' in such projects, when they are not leveraging the `store` feature of AppProvider.
 
 It will be great to be able to not have to include redux and react-redux as dependencies in such cases.
 
@@ -22,7 +25,7 @@ Decision
 
 A method to enable the removal of the dependencies `redux` and `react-redux` from mentioned client projects is to leverage optionalDependencies.
 
-According to npm documentation:
+According to `npm documentation <https://docs.npmjs.com/cli/v8/configuring-npm/package-json#optionaldependencies>`_:
 
 > optionalDependencies are dependencies that do not necessarily need to be installed.
   If a dependency can be used, but you would like npm to proceed if it cannot be found or fails to install,
@@ -32,9 +35,8 @@ Therefore if we were to move the redux and react-redux into optionalDependencies
 when these deps are missing.
 
 In addition, since the `OptionalReduxProvider` makes use of the import of react-redux, it may need to also make a safe import such that
-a missing package react-redux does not cause a failure. Instead it can simply detect the absence of the package
-and return, something like this
-
+a missing package react-redux does not cause a failure, as noted in the above link. Instead it can simply detect the absence of the package
+and return, something like this::
 
     if (store === null || !Provider) {
         return (
@@ -49,3 +51,5 @@ Consequences
 For consumers that use frontend-platform but do make use of the redux store feature of AppProvider, there should be no impact.
 
 However, for consumers that do not use that feature, they should no longer need to depend on redux or react-redux.
+
+Also, this will help bundle sizes to be smaller for consumers where this exclusion applies.

--- a/docs/decisions/0006-make-redux-deps-optional.rst
+++ b/docs/decisions/0006-make-redux-deps-optional.rst
@@ -14,8 +14,13 @@ However, they are still required to install these dependencies due to the usage 
 react-redux and redux are peerDependencies. To be precise, the OptionalReduxProvider used by AppProvider is what uses the
 react-redux Provider in case a store prop is passed to AppProvider.
 
-However, it's only optional from a code perspecitve, it's not optional from a dependency perspective right now.
+Specifically, if an app like frontend-app-learner-portal-enterprise were to uninstall the redux and
+react-redux dependencies, it fails with an error during module loading like this::
 
+    ERROR in ./node_modules/@edx/frontend-platform/react/OptionalReduxProvider.js 3:0-39
+    Module not found: Error: Can't resolve 'react-redux' in 'frontend-app-learner-portal-enterprise/node_modules/@edx/frontend-platform/react'
+
+Therefore, redux and react-redux are only optional from a code perspecitve, not from a dependency perspective right now.
 This means there is extra overhead and confusion on seeing 'redux' and 'react-redux' in such projects, when they are not leveraging the `store` feature of AppProvider.
 
 It will be great to be able to not have to include redux and react-redux as dependencies in such cases.

--- a/docs/decisions/0006-make-redux-deps-optional.rst
+++ b/docs/decisions/0006-make-redux-deps-optional.rst
@@ -1,0 +1,51 @@
+Consumers of frontend-platform that don't use redux are still required to install redux dependencies
+==========================================
+
+Status
+------
+
+Review
+
+Context
+-------
+
+Some consumers of frontend-platform, such as frontend-app-learner-portal-enterprise, no longer use redux or react-redux.
+However, they are still required to install these dependencies due to the usage of react-redux in AppProvider, and the fact that
+react-redux and redux are peerDependencies.
+
+This means there is extra overhead and confusion in such projects, when they are not leveraging the `store` feature of AppProvider.
+
+It will be great to be able to not have to include redux and react-redux as dependencies in such cases.
+
+Decision
+--------
+
+A method to enable the removal of the dependencies `redux` and `react-redux` from mentioned client projects is to leverage optionalDependencies.
+
+According to npm documentation:
+
+> optionalDependencies are dependencies that do not necessarily need to be installed.
+  If a dependency can be used, but you would like npm to proceed if it cannot be found or fails to install,
+  then you may put it in the optionalDependencies object.
+
+Therefore if we were to move the redux and react-redux into optionalDependencies instead, consumers will no longer fail build
+when these deps are missing.
+
+In addition, since the `OptionalReduxProvider` makes use of the import of react-redux, it may need to also make a safe import such that
+a missing package react-redux does not cause a failure. Instead it can simply detect the absence of the package
+and return, something like this
+
+```
+if (store === null || !Provider) {
+    return (
+      <>{children}</>
+    );
+  }
+```
+
+Consequences
+--------
+
+For consumers that use frontend-platform but do make use of the redux store feature of AppProvider, there should be no impact.
+
+However, for consumers that do not use that feature, they should no longer need to depend on redux or react-redux.

--- a/docs/decisions/0006-make-redux-deps-optional.rst
+++ b/docs/decisions/0006-make-redux-deps-optional.rst
@@ -35,13 +35,13 @@ In addition, since the `OptionalReduxProvider` makes use of the import of react-
 a missing package react-redux does not cause a failure. Instead it can simply detect the absence of the package
 and return, something like this
 
-```
-if (store === null || !Provider) {
-    return (
-      <>{children}</>
-    );
-  }
-```
+
+    if (store === null || !Provider) {
+        return (
+        <>{children}</>
+        );
+    }
+
 
 Consequences
 --------


### PR DESCRIPTION
**Description:**

An ADR to explore a way to make redux and react-redux optional dependencies for consumers of frontend-platform that don't actually use the 'store' feature of the AppProvider

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
