### PR TITLE
feat: Include user's name in authenticated user object

### DIFF
--- a/src/auth/AxiosJwtAuthService.js
+++ b/src/auth/AxiosJwtAuthService.js
@@ -207,6 +207,7 @@ class AxiosJwtAuthService {
         username: decodedAccessToken.preferred_username,
         roles: decodedAccessToken.roles || [],
         administrator: decodedAccessToken.administrator,
+        name: decodedAccessToken.name,
       });
     } else {
       this.setAuthenticatedUser(null);

--- a/src/auth/AxiosJwtAuthService.test.jsx
+++ b/src/auth/AxiosJwtAuthService.test.jsx
@@ -737,6 +737,7 @@ describe('hydrateAuthenticatedUser', () => {
       username: 'the_user',
       roles: [],
       administrator: false,
+      name: 'test user',
     });
     axiosMock.onGet(`${authOptions.config.LMS_BASE_URL}/api/user/v1/accounts/the_user`).reply(200, {
       additional: 'data',
@@ -749,6 +750,7 @@ describe('hydrateAuthenticatedUser', () => {
       roles: [],
       administrator: false,
       additional: 'data',
+      name: 'test user',
     });
   });
 });

--- a/src/testing/initializeMockApp.test.js
+++ b/src/testing/initializeMockApp.test.js
@@ -47,6 +47,7 @@ describe('initializeMockApp', () => {
       username: 'Mock User',
       roles: [],
       administrator: false,
+      name: 'mock tester',
     });
     ensureAuthenticatedUser();
 


### PR DESCRIPTION
**Description:**

Includes the user's "name" field in our authenticated user object.  

Example use case:

As a user, I'd like my name to appear in the pulldown in the header in edX rather than my username.

![image](https://user-images.githubusercontent.com/21342568/150280738-1fd58dfa-08f1-45cf-8aef-8089dcc37444.png)


The idea is, After getting the name attribute in user object, we can override the desired behaviour in our fork of Header MFE e.g. [frontend-component-header-mitol](https://github.com/mitodl/frontend-component-header-mitol)

**Issue:**
fixes: https://github.com/mitodl/mitxpro/issues/2342



**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
