### PR TITLE
fix: wrap ErrorPage with IntlProvider and pass messages

### DIFF
--- a/example/ExamplePage.jsx
+++ b/example/ExamplePage.jsx
@@ -46,6 +46,7 @@ class ExamplePage extends Component {
         {this.renderAuthenticatedUser()}
         <p>EXAMPLE_VAR env var came through: <strong>{getConfig().EXAMPLE_VAR}</strong></p>
         <p>Visit <Link to="/authenticated">authenticated page</Link>.</p>
+        <p>Visit <Link to="/error_example">error page</Link>.</p>
       </div>
     );
   }

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -11,7 +11,6 @@ import {
 } from '@edx/frontend-platform/react';
 import { APP_INIT_ERROR, APP_READY, initialize } from '@edx/frontend-platform';
 import { subscribe } from '@edx/frontend-platform/pubSub';
-import { IntlProvider } from '@edx/frontend-platform/i18n';
 
 import './index.scss';
 import ExamplePage from './ExamplePage';
@@ -33,7 +32,7 @@ subscribe(APP_READY, () => {
 });
 
 subscribe(APP_INIT_ERROR, (error) => {
-  ReactDOM.render(<IntlProvider><ErrorPage message={error.message} /></IntlProvider>, document.getElementById('root'));
+  ReactDOM.render(<ErrorPage message={error.message} />, document.getElementById('root'));
 });
 
 initialize({

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
-        "@formatjs/intl-pluralrules": "^4.3.3",
-        "@formatjs/intl-relativetimeformat": "^10.0.1",
+        "@formatjs/intl-pluralrules": "4.3.3",
+        "@formatjs/intl-relativetimeformat": "10.0.1",
         "axios": "0.26.1",
         "axios-cache-adapter": "2.7.3",
         "form-urlencoded": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
   },
   "dependencies": {
     "@cospired/i18n-iso-languages": "2.2.0",
-    "@formatjs/intl-pluralrules": "^4.3.3",
-    "@formatjs/intl-relativetimeformat": "^10.0.1",
+    "@formatjs/intl-pluralrules": "4.3.3",
+    "@formatjs/intl-relativetimeformat": "10.0.1",
     "axios": "0.26.1",
     "axios-cache-adapter": "2.7.3",
     "form-urlencoded": "4.1.4",

--- a/src/react/ErrorBoundary.test.jsx
+++ b/src/react/ErrorBoundary.test.jsx
@@ -2,17 +2,40 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ErrorBoundary from './ErrorBoundary';
-
-import { logError } from '../logging';
-import { IntlProvider } from '../i18n';
-
-jest.mock('../logging');
+import { initialize } from '..';
 
 describe('ErrorBoundary', () => {
-  beforeEach(() => {
+  const logError = jest.fn();
+  const logInfo = jest.fn();
+
+  beforeEach(async () => {
     // This is a gross hack to suppress error logs in the invalid parentSelector test
     jest.spyOn(console, 'error');
     global.console.error.mockImplementation(() => {});
+
+    jest.clearAllMocks();
+
+    await initialize({
+      loggingService: jest.fn(() => ({
+        logError,
+        logInfo,
+      })),
+      messages: {
+        ar: {},
+        'es-419': {},
+        fr: {},
+        'zh-cn': {},
+        ca: {},
+        he: {},
+        id: {},
+        'ko-kr': {},
+        pl: {},
+        'pt-br': {},
+        ru: {},
+        th: {},
+        uk: {},
+      },
+    });
   });
 
   afterEach(() => {
@@ -37,15 +60,14 @@ describe('ErrorBoundary', () => {
     };
 
     const component = (
-      <IntlProvider locale="en" messages={{}}>
-        <ErrorBoundary>
-          <ExplodingComponent />
-        </ErrorBoundary>
-      </IntlProvider>
+      <ErrorBoundary>
+        <ExplodingComponent />
+      </ErrorBoundary>
     );
+
     mount(component);
 
     expect(logError).toHaveBeenCalledTimes(1);
-    expect(logError).toHaveBeenCalledWith(new Error('booyah'), { stack: '\n    in ExplodingComponent\n    in ErrorBoundary\n    in IntlProvider (created by WrapperComponent)\n    in WrapperComponent' });
+    expect(logError).toHaveBeenCalledWith(new Error('booyah'), { stack: '\n    in ExplodingComponent\n    in ErrorBoundary (created by WrapperComponent)\n    in WrapperComponent' });
   });
 });

--- a/src/react/ErrorBoundary.test.jsx
+++ b/src/react/ErrorBoundary.test.jsx
@@ -2,38 +2,18 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ErrorBoundary from './ErrorBoundary';
-import { initialize } from '..';
+import { initializeMockApp } from '..';
 
 describe('ErrorBoundary', () => {
-  const logError = jest.fn();
-  const logInfo = jest.fn();
+  let logError = jest.fn();
 
   beforeEach(async () => {
     // This is a gross hack to suppress error logs in the invalid parentSelector test
     jest.spyOn(console, 'error');
     global.console.error.mockImplementation(() => {});
 
-    await initialize({
-      loggingService: jest.fn(() => ({
-        logError,
-        logInfo,
-      })),
-      messages: {
-        ar: {},
-        'es-419': {},
-        fr: {},
-        'zh-cn': {},
-        ca: {},
-        he: {},
-        id: {},
-        'ko-kr': {},
-        pl: {},
-        'pt-br': {},
-        ru: {},
-        th: {},
-        uk: {},
-      },
-    });
+    const { loggingService } = initializeMockApp();
+    logError = loggingService.logError;
   });
 
   afterEach(() => {

--- a/src/react/ErrorBoundary.test.jsx
+++ b/src/react/ErrorBoundary.test.jsx
@@ -13,8 +13,6 @@ describe('ErrorBoundary', () => {
     jest.spyOn(console, 'error');
     global.console.error.mockImplementation(() => {});
 
-    jest.clearAllMocks();
-
     await initialize({
       loggingService: jest.fn(() => ({
         logError,
@@ -40,6 +38,7 @@ describe('ErrorBoundary', () => {
 
   afterEach(() => {
     global.console.error.mockRestore();
+    jest.clearAllMocks();
   });
 
   it('should render children if no error', () => {

--- a/src/react/ErrorPage.jsx
+++ b/src/react/ErrorPage.jsx
@@ -1,10 +1,17 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Button, Container, Row, Col,
 } from '@edx/paragon';
 
-import { FormattedMessage } from '../i18n';
+import { useAppEvent } from './hooks';
+import {
+  FormattedMessage,
+  IntlProvider,
+  getMessages,
+  getLocale,
+  LOCALE_CHANGED,
+} from '../i18n';
 
 /**
  * An error page that displays a generic message for unexpected errors.  Also contains a "Try
@@ -13,15 +20,22 @@ import { FormattedMessage } from '../i18n';
  * @memberof module:React
  * @extends {Component}
  */
-class ErrorPage extends Component {
-  /* istanbul ignore next */
-  reload() {
-    global.location.reload();
-  }
+function ErrorPage({
+  message,
+}) {
+  const [locale, setLocale] = useState(getLocale());
 
-  render() {
-    const { message } = this.props;
-    return (
+  useAppEvent(LOCALE_CHANGED, () => {
+    setLocale(getLocale());
+  });
+
+  /* istanbul ignore next */
+  const reload = () => {
+    global.location.reload();
+  };
+
+  return (
+    <IntlProvider locale={locale} messages={getMessages()}>
       <Container fluid className="py-5 justify-content-center align-items-start text-center">
         <Row>
           <Col>
@@ -37,7 +51,7 @@ class ErrorPage extends Component {
                 <p>{message}</p>
               </div>
             )}
-            <Button onClick={this.reload}>
+            <Button onClick={reload}>
               <FormattedMessage
                 id="unexpected.error.button.text"
                 defaultMessage="Try again"
@@ -47,8 +61,8 @@ class ErrorPage extends Component {
           </Col>
         </Row>
       </Container>
-    );
-  }
+    </IntlProvider>
+  );
 }
 
 ErrorPage.propTypes = {


### PR DESCRIPTION
**Description:**

The `ErrorPage` relies on translated messages via react-intl's `FormattedMessage` component. However, it currently relies on consumers (i.e., MFEs) to wrap `ErrorPage` with an `IntlProvider` and pass a `locale` and `messages` prop. Instead, this PR proposes adding an `IntlProvider` to `ErrorPage`, pre-configuring its `locale` and `messages` props from the existing configuration in `@edx/frontend-platform` via its initialization.

**Merge checklist:**

- [x] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [x] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
