### PR TITLE
feat: add SUPPORT_URL to config

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -25,3 +25,4 @@ FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
 IGNORED_ERROR_REGEX=
 MFE_CONFIG_API_URL=
 APP_ID=
+SUPPORT_URL=https://support.edx.org

--- a/.env.test
+++ b/.env.test
@@ -25,3 +25,4 @@ FAVICON_URL=https://edx-cdn.org/v3/default/favicon.ico
 IGNORED_ERROR_REGEX=
 MFE_CONFIG_API_URL=
 APP_ID=
+SUPPORT_URL=https://support.edx.org

--- a/src/config.js
+++ b/src/config.js
@@ -69,6 +69,7 @@ let config = {
   FAVICON_URL: process.env.FAVICON_URL,
   MFE_CONFIG_API_URL: process.env.MFE_CONFIG_API_URL,
   APP_ID: process.env.APP_ID,
+  SUPPORT_URL: process.env.SUPPORT_URL,
 };
 
 /**
@@ -197,4 +198,5 @@ export function ensureConfig(keys, requester = 'unspecified application code') {
  * @property {string} FAVICON_URL
  * @property {string} MFE_CONFIG_API_URL
  * @property {string} APP_ID
+ * @property {string} SUPPORT_URL
  */

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -34,6 +34,7 @@ process.env.LOGO_WHITE_URL = 'https://edx-cdn.org/v3/default/logo-white.svg';
 process.env.FAVICON_URL = 'https://edx-cdn.org/v3/default/favicon.ico';
 process.env.MFE_CONFIG_API_URL = '';
 process.env.APP_ID = '';
+process.env.SUPPORT_URL = 'https://support.edx.org';
 
 /* Auth test variables
 


### PR DESCRIPTION
### [INF-459](https://2u-internal.atlassian.net/browse/INF-459)

### **Description:**
This PR adds `config.SUPPORT_URL` for all frontends to use.
We needed this in `frontend-app-discussions` in config to add `Help` link in `LearningHeader`. 

Related PR: https://github.com/openedx/frontend-app-discussions/pull/251


**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
