### PR TITLE
fix: ignored import/extensions rule for lang extensions

### DIFF
--- a/src/i18n/countries.js
+++ b/src/i18n/countries.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 import COUNTRIES, { langs as countryLangs } from 'i18n-iso-countries';
 
 import { getPrimaryLanguageSubtag } from './lib';
@@ -10,20 +11,20 @@ import { getPrimaryLanguageSubtag } from './lib';
  * TODO: When we start dynamically loading translations only for the current locale, change this.
  */
 
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ar'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/en'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/es'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/fr'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/zh'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ca'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/he'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/id'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ko'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/pl'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/pt'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ru'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ar.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/en.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/es.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/fr.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/zh.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ca.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/he.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/id.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ko.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/pl.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/pt.json'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ru.json'));
 // COUNTRIES.registerLocale(require('i18n-iso-countries/langs/th.json')); // Doesn't exist in lib.
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/uk'));
+COUNTRIES.registerLocale(require('i18n-iso-countries/langs/uk.json'));
 
 /**
  * Provides a lookup table of country IDs to country names for the current locale.

--- a/src/i18n/languages.js
+++ b/src/i18n/languages.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/extensions */
 import LANGUAGES, { langs as languageLangs } from '@cospired/i18n-iso-languages';
 
 import { getPrimaryLanguageSubtag } from './lib';
@@ -14,16 +15,16 @@ import { getPrimaryLanguageSubtag } from './lib';
  */
 
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/ar.json'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/en'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/es'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/fr'));
+LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/en.json'));
+LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/es.json'));
+LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/fr.json'));
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/zh.json'));
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/ca.json'));
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/he.json'));
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/id.json'));
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/ko.json'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/pl'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/pt'));
+LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/pl.json'));
+LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/pt.json'));
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/ru.json'));
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/th.json'));
 // LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/uk.json'));


### PR DESCRIPTION
**Description:**
- `import/extensions` rule was satisfied during frontend-build upgrade which resulted in resolution error for i18l lang modules for consumers, that change was reverted

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
