### PR TITLE
feat: use axios cache interceptor for cache implementation

### DIFF
--- a/docs/how_tos/caching.rst
+++ b/docs/how_tos/caching.rst
@@ -33,9 +33,9 @@ Both server and client caching can be combined to provide best of both worlds. R
 How do I use client caching with ``@edx/frontend-platform?``
 ************************************************************
 
-The ``@edx/frontend-platform`` package supports an Axios HTTP client that uses client caching under the hood through the use of `axios-cache-adapter <https://www.npmjs.com/package/axios-cache-adapter>`_.
+The ``@edx/frontend-platform`` package supports an Axios HTTP client that uses client caching under the hood through the use of `axios-cache-interceptor <https://www.npmjs.com/package/axios-cache-interceptor>`_.
 
-``axios-cache-adapter`` is configured to use `localForage <https://www.npmjs.com/package/localforage>`_ as its store; ``localForage`` is a package that provides a similar API to browser's localStorage, except is asynchronous (non-blocking). ``localForage`` is configured to prefer using IndexedDB, falling back to localStorage if browser support for IndexedDB is lacking. If all else fails, an in-memory store is used instead. IndexedDB is more performant and may contain a broader range (and volume) of data in comparison to localStorage (see `browser support <https://caniuse.com/indexeddb>`_ for IndexedDB).
+Currently, `localForage <https://www.npmjs.com/package/localforage>`_ is configured to be the underlying storage; ``localForage`` is a package that provides a similar API to browser's localStorage, except is asynchronous (non-blocking). ``localForage`` is configured to prefer using IndexedDB, falling back to localStorage if browser support for IndexedDB is lacking. If all else fails, an in-memory store is used instead. IndexedDB is more performant and may contain a broader range (and volume) of data in comparison to localStorage (see `browser support <https://caniuse.com/indexeddb>`_ for IndexedDB).
 
 When importing an HTTP client from ``@edx/frontend-platform``, you may specify options for how you wish to configure the HTTP client::
 
@@ -44,7 +44,17 @@ When importing an HTTP client from ``@edx/frontend-platform``, you may specify o
   // ``cachedHttpClient`` is configured to use client caching under the hood.
   const cachedHttpClient = getAuthenticatedHttpClient({ useCache: true });
 
-The examples below demonstrate how to configure the caching behavior on a per-request basis. For more details about how to configure the caching behavior, you may refer to the `axios-cache-adapter documentation <https://www.npmjs.com/package/axios-cache-adapter>`_.
+The examples below demonstrate how to configure commonly used caching behavior on a per-request basis. For more use-cases, you may refer to the `axios-cache-interceptor documentation <https://axios-cache-interceptor.js.org/#/pages/per-request-configuration>`_.
+
+Overriding the request id
+=========================
+
+Every request passed through the axios-cache-interceptor interceptor has an id. Each request id is responsible for binding a request to its cache,
+for referencing (or invalidating) it later.
+
+  const { id: requestId} = cachedHttpClient.get('/courses/', {
+    id: 'custom-id'
+  });
 
 Modify expiry behavior for a single request
 ===========================================
@@ -53,7 +63,7 @@ By default, API requests using the cached HTTP client will be cached for 5 minut
 
   cachedHttpClient.get('/courses/', {
     cache: {
-      maxAge: 15 * 60 * 1000, // 15 minutes instead of the default 5.
+      ttl: 15 * 60 * 1000, // 15 minutes instead of the default 5.
     },
   });
 
@@ -62,7 +72,16 @@ Invalidate cache for a single request
 
 In certain situations, it may be necessary to invalidate cached data to force a true network request to the server::
 
-  cachedHttpClient.get('/courses/', { clearCacheEntry: true });
+  cachedHttpClient.get('/courses/', {
+    cache: {
+      override: true, // This will replace the cache when the response arrives.
+    },
+  });
+
+To remove the cache of a request::
+
+    await axios.storage.remove('list-posts');
+
 
 Check if response is served from network or from cache
 ======================================================
@@ -70,5 +89,5 @@ Check if response is served from network or from cache
 If there is a need to know whether a response was served from the network (i.e., server) or from the local client cache, you may refer to the ``response.request`` object::
 
   cachedHttpClient.get('/courses/').then((response) => {
-    console.log(response.request.fromCache); // will be true if served from the client cache, undefined otherwise
+    console.log(response.cached); // will be true if served from the client cache, false otherwise
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
         "@formatjs/intl-relativetimeformat": "10.0.1",
-        "axios": "0.26.1",
-        "axios-cache-adapter": "2.7.3",
+        "axios": "0.27.2",
+        "axios-cache-interceptor": "0.10.7",
         "form-urlencoded": "4.1.4",
         "glob": "7.2.0",
         "history": "4.10.1",
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
+        "@edx/browserslist-config": "^1.1.0",
         "@edx/frontend-build": "^12.0.3",
         "@edx/paragon": "20.2.0",
         "axios-mock-adapter": "1.20.0",
@@ -1933,6 +1934,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@edx/brand-openedx/-/brand-openedx-1.1.0.tgz",
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ==",
+      "dev": true
+    },
+    "node_modules/@edx/browserslist-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.1.0.tgz",
+      "integrity": "sha512-2lxL2emt81vJZWa5ujil8yK2eBKVpbPMULI/ocqMuoJ6QVAKXcuonVGpzBHvKvliBzP14UDaF+yN5Ek/nUTByQ==",
       "dev": true
     },
     "node_modules/@edx/eslint-config": {
@@ -4987,8 +4994,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -5048,23 +5054,25 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
       }
     },
-    "node_modules/axios-cache-adapter": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/axios-cache-adapter/-/axios-cache-adapter-2.7.3.tgz",
-      "integrity": "sha512-A+ZKJ9lhpjthOEp4Z3QR/a9xC4du1ALaAsejgRGrH9ef6kSDxdFrhRpulqsh9khsEnwXxGfgpUuDp1YXMNMEiQ==",
+    "node_modules/axios-cache-interceptor": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-0.10.7.tgz",
+      "integrity": "sha512-UjpxChG5DpF6Kf1IPGMLOzRDNL8ZNS6TOn1jTaVvCE7cWFU904jJwi0T1s+IbijpnLEjK2iq5uLIuR8Sj+RsFQ==",
       "dependencies": {
-        "cache-control-esm": "1.0.0",
-        "md5": "^2.2.1"
+        "cache-parser": "^1.2.4",
+        "fast-defer": "^1.1.7",
+        "object-code": "^1.2.4"
       },
-      "peerDependencies": {
-        "axios": "~0.21.1"
+      "funding": {
+        "url": "https://github.com/ArthurFiorette/axios-cache-interceptor?sponsor=1"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -5079,6 +5087,19 @@
       },
       "peerDependencies": {
         "axios": ">= 0.9.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -6396,10 +6417,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/cache-control-esm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cache-control-esm/-/cache-control-esm-1.0.0.tgz",
-      "integrity": "sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g=="
+    "node_modules/cache-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
+      "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
     },
     "node_modules/cacheable-request": {
       "version": "2.1.4",
@@ -6632,14 +6653,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cheerio": {
@@ -6989,7 +7002,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -7290,14 +7302,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/crypto-random-string": {
@@ -8002,7 +8006,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10143,6 +10146,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-defer": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/fast-defer/-/fast-defer-1.1.7.tgz",
+      "integrity": "sha512-tJ01ulDWT2WhqxMKS20nXX6wyX2iInBYpbN3GO7yjKwXMY4qvkdBRxak9IFwBLlFDESox+SwSvqMCZDfe1tqeg=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.11",
@@ -15089,6 +15097,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/jquery": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -15714,21 +15729,6 @@
         "css-mediaquery": "^0.1.2"
       }
     },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
-    },
-    "node_modules/md5/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -15821,7 +15821,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -15830,7 +15829,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -16331,6 +16329,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/object-code": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/object-code/-/object-code-1.2.4.tgz",
+      "integrity": "sha512-uGq4ETUuWe+GA586NXEriiaozNuff+YNFXlpD8cVrM1GoiuTZpCABP+bZCWDrvQDoCiSTyiWAFHD/HF/iwhb2w=="
     },
     "node_modules/object-copy": {
       "version": "0.1.0",
@@ -17454,6 +17457,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/portfinder": {
@@ -24635,6 +24650,12 @@
       "integrity": "sha512-ne2ZKF1r0akkt0rEzCAQAk4cTDTI2GiWCpc+T7ldQpw9X57OnUB16dKsFNe40C9uEjL5h3Ps/ZsFM5dm4cIkEQ==",
       "dev": true
     },
+    "@edx/browserslist-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.1.0.tgz",
+      "integrity": "sha512-2lxL2emt81vJZWa5ujil8yK2eBKVpbPMULI/ocqMuoJ6QVAKXcuonVGpzBHvKvliBzP14UDaF+yN5Ek/nUTByQ==",
+      "dev": true
+    },
     "@edx/eslint-config": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@edx/eslint-config/-/eslint-config-3.1.0.tgz",
@@ -27082,8 +27103,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -27118,20 +27138,34 @@
       "dev": true
     },
     "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
-    "axios-cache-adapter": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/axios-cache-adapter/-/axios-cache-adapter-2.7.3.tgz",
-      "integrity": "sha512-A+ZKJ9lhpjthOEp4Z3QR/a9xC4du1ALaAsejgRGrH9ef6kSDxdFrhRpulqsh9khsEnwXxGfgpUuDp1YXMNMEiQ==",
+    "axios-cache-interceptor": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/axios-cache-interceptor/-/axios-cache-interceptor-0.10.7.tgz",
+      "integrity": "sha512-UjpxChG5DpF6Kf1IPGMLOzRDNL8ZNS6TOn1jTaVvCE7cWFU904jJwi0T1s+IbijpnLEjK2iq5uLIuR8Sj+RsFQ==",
       "requires": {
-        "cache-control-esm": "1.0.0",
-        "md5": "^2.2.1"
+        "cache-parser": "^1.2.4",
+        "fast-defer": "^1.1.7",
+        "object-code": "^1.2.4"
       }
     },
     "axios-mock-adapter": {
@@ -28190,10 +28224,10 @@
         "unset-value": "^1.0.0"
       }
     },
-    "cache-control-esm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cache-control-esm/-/cache-control-esm-1.0.0.tgz",
-      "integrity": "sha512-Fa3UV4+eIk4EOih8FTV6EEsVKO0W5XWtNs6FC3InTfVz+EjurjPfDXY5wZDo/lxjDxg5RjNcurLyxEJBcEUx9g=="
+    "cache-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/cache-parser/-/cache-parser-1.2.4.tgz",
+      "integrity": "sha512-O0KwuHuJnbHUrghHi2kGp0SxnWSIBXTYt7M8WVhW0kbPRUNUKoE/Of6e1rRD6AAxmfxFunKnt90yEK09D+sc5g=="
     },
     "cacheable-request": {
       "version": "2.1.4",
@@ -28374,11 +28408,6 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
-    },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
     "cheerio": {
       "version": "1.0.0-rc.10",
@@ -28657,7 +28686,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -28894,11 +28922,6 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "crypto-random-string": {
       "version": "2.0.0",
@@ -29429,8 +29452,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -31105,6 +31127,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "fast-defer": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/fast-defer/-/fast-defer-1.1.7.tgz",
+      "integrity": "sha512-tJ01ulDWT2WhqxMKS20nXX6wyX2iInBYpbN3GO7yjKwXMY4qvkdBRxak9IFwBLlFDESox+SwSvqMCZDfe1tqeg=="
     },
     "fast-glob": {
       "version": "3.2.11",
@@ -34771,6 +34798,13 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.1.tgz",
+      "integrity": "sha512-opJeO4nCucVnsjiXOE+/PcCgYw9Gwpvs/a6B1LL/lQhwWwpbVEVYDZ1FokFr8PRc7ghYlrFPuyHuiiDNTQxmcw==",
+      "dev": true,
+      "peer": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -35281,23 +35315,6 @@
         "css-mediaquery": "^0.1.2"
       }
     },
-    "md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-        }
-      }
-    },
     "mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -35368,14 +35385,12 @@
     "mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "requires": {
         "mime-db": "1.52.0"
       }
@@ -35759,6 +35774,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-code": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/object-code/-/object-code-1.2.4.tgz",
+      "integrity": "sha512-uGq4ETUuWe+GA586NXEriiaozNuff+YNFXlpD8cVrM1GoiuTZpCABP+bZCWDrvQDoCiSTyiWAFHD/HF/iwhb2w=="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -36588,6 +36608,13 @@
           }
         }
       }
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+      "dev": true,
+      "peer": true
     },
     "portfinder": {
       "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/edx/frontend-platform#readme",
   "devDependencies": {
+    "@edx/browserslist-config": "^1.1.0",
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-build": "^12.0.3",
     "@edx/paragon": "20.2.0",
@@ -53,8 +54,8 @@
     "@cospired/i18n-iso-languages": "2.2.0",
     "@formatjs/intl-pluralrules": "4.3.3",
     "@formatjs/intl-relativetimeformat": "10.0.1",
-    "axios": "0.26.1",
-    "axios-cache-adapter": "2.7.3",
+    "axios": "0.27.2",
+    "axios-cache-interceptor": "0.10.7",
     "form-urlencoded": "4.1.4",
     "glob": "7.2.0",
     "history": "4.10.1",

--- a/src/auth/LocalForageCache.js
+++ b/src/auth/LocalForageCache.js
@@ -1,7 +1,13 @@
 /* eslint-disable no-underscore-dangle */
 import localforage from 'localforage';
 import memoryDriver from 'localforage-memoryStorageDriver';
-import { setup } from 'axios-cache-adapter';
+import {
+  setupCache,
+  defaultKeyGenerator,
+  defaultHeaderInterpreter,
+  buildStorage,
+} from 'axios-cache-interceptor';
+import axios from 'axios';
 
 /**
  * Async function to configure localforage and setup the cache
@@ -24,17 +30,49 @@ export default async function configureCache() {
     name: 'edx-cache',
   });
 
-  // Set up the cache with a default maxAge of 5 minutes and using localforage as the storage source
-  return setup({
-    cache: {
-      maxAge: 5 * 60 * 1000,
-      store: forageStore,
-      exclude: { query: false },
-      invalidate: async (config, request) => {
-        if (request.clearCacheEntry) {
-          await config.store.removeItem(config.uuid);
-        }
-      },
+  const forageStoreAdapter = buildStorage({
+    async find(key) {
+      const result = await forageStore.getItem(`axios-cache:${key}`);
+      return JSON.parse(result);
+    },
+
+    async set(key, value) {
+      await forageStore.setItem(`axios-cache:${key}`, JSON.stringify(value));
+    },
+
+    async remove(key) {
+      await forageStore.removeItem(`axios-cache:${key}`);
     },
   });
+
+  // only GET methods are cached by default
+  return setupCache(
+    // axios instance
+    axios.create(),
+    {
+      ttl: 5 * 60 * 1000, // default maxAge of 5 minutes
+      // The storage to save the cache data. There are more available by default.
+      //
+      // https://axios-cache-interceptor.js.org/#/pages/storages
+      storage: forageStoreAdapter,
+
+      // The mechanism to generate a unique key for each request.
+      //
+      // https://axios-cache-interceptor.js.org/#/pages/request-id
+      generateKey: defaultKeyGenerator,
+
+      // The mechanism to interpret headers (when cache.interpretHeader is true).
+      //
+      // https://axios-cache-interceptor.js.org/#/pages/global-configuration?id=headerinterpreter
+      headerInterpreter: defaultHeaderInterpreter,
+
+      // The function that will receive debug information.
+      // NOTE: For this to work, you need to enable development mode.
+      //
+      // https://axios-cache-interceptor.js.org/#/pages/development-mode
+      // https://axios-cache-interceptor.js.org/#/pages/global-configuration?id=debug
+      // eslint-disable-next-line no-console
+      debug: console.log,
+    },
+  );
 }


### PR DESCRIPTION
Swapping out `axios-cache-adapter` for `axios-cache-interceptor` since `axios-cache-adapter` is no longer maintained.
All of the previous caching behavior is supported, with additional ones supported by `axios-cache-interceptor`.

This is a **breaking change**.
Usages of `clearCacheEntry` will have to be updated.

**Description:**

Describe what this pull request changes, and why. Include implications for people using this change.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/edx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
