### PR TITLE
feat: remove identify for anon users

### DIFF
--- a/src/analytics/SegmentAnalyticsService.js
+++ b/src/analytics/SegmentAnalyticsService.js
@@ -174,7 +174,7 @@ class SegmentAnalyticsService {
    * @param {*} [traits]
    * @returns {Promise} Promise that will resolve once the document readyState is complete
    */
-  identifyAnonymousUser(traits) {
+  identifyAnonymousUser(traits) { // eslint-disable-line no-unused-vars
     if (!this.segmentInitialized) {
       return Promise.resolve();
     }
@@ -187,7 +187,9 @@ class SegmentAnalyticsService {
         if (global.analytics.user().id()) {
           global.analytics.reset();
         }
-        global.analytics.identify(traits);
+        // We don’t need to call `identify` for anonymous users and can just make the value of
+        // hasIdentifyBeenCalled true. Segment automatically assigns them an anonymousId, so
+        // just calling `page` and `track` works fine without identify.
         this.hasIdentifyBeenCalled = true;
         resolve();
       });

--- a/src/analytics/interface.test.js
+++ b/src/analytics/interface.test.js
@@ -115,24 +115,20 @@ describe('Analytics', () => {
     });
 
     describe('analytics identifyAnonymousUser', () => {
-      it('calls Segment identify on success - no previous segment user', () => {
+      it('does not call segment reset for no previous segment user', () => {
         window.analytics.user = () => ({ id: () => null });
         const testTraits = { anything: 'Yay!' };
         identifyAnonymousUser(testTraits);
 
         expect(window.analytics.reset.mock.calls.length).toBe(0);
-        expect(window.analytics.identify.mock.calls.length).toBe(1);
-        expect(window.analytics.identify).toBeCalledWith(testTraits);
       });
 
-      it('calls Segment identify on success - previous segment user', () => {
+      it('calls segment reset for a previous segment user', () => {
         window.analytics.user = () => ({ id: () => 7 });
         const testTraits = { anything: 'Yay!' };
         identifyAnonymousUser(testTraits);
 
         expect(window.analytics.reset.mock.calls.length).toBe(1);
-        expect(window.analytics.identify.mock.calls.length).toBe(1);
-        expect(window.analytics.identify).toBeCalledWith(testTraits);
       });
     });
 


### PR DESCRIPTION
**Description:**

Removed the identify call for anonymous users as it is causing anonymous id assigned by segment to change whenever a user lands on authn frontend.

<img width="685" alt="image" src="https://user-images.githubusercontent.com/40633976/199904722-5d36e4dc-fe2b-4511-b2fa-3dda76baad6a.png">


**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
