### PR TITLE
fix: used node 18 to fix release workflow which has latest semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js Env
-        run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
-
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "${{ env.NODE_VER }}"
-
-      # This is a temporary "hack" to unblock CI/releases, as ideally we should avoid needing to pin NPM to a specific minor version. By doing
-      # so, we are basically deferring clean up of peer dependencies to a later time. See https://github.com/npm/cli/issues/4664 for more details.
-      - name: Pin NPM version
-        run: npm install -g npm@8.5.x
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
**Description:**

Used node 18 in `release` workflow which was breaking due to latest semantic release which has node 18 dependency.
Tested `npm ci`, `npm run build` and `npm run docs` locally 

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
