### PR TITLE
fix: handle missing window.matchMedia in useTrackColorSchemeChoice

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,5 @@ module.exports = createConfig('jest', {
   setupFiles: [
     '<rootDir>/src/setupTest.js',
   ],
+  testTimeout: 20000,
 });

--- a/src/react/hooks.js
+++ b/src/react/hooks.js
@@ -33,16 +33,18 @@ export const useTrackColorSchemeChoice = () => {
   useEffect(() => {
     const trackColorSchemeChoice = ({ matches }) => {
       const preferredColorScheme = matches ? 'dark' : 'light';
-
       sendTrackEvent('openedx.ui.frontend-platform.prefers-color-scheme.selected', { preferredColorScheme });
     };
-
-    const colorSchemeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-
-    // send user's initial choice
-    trackColorSchemeChoice(colorSchemeQuery);
-
-    colorSchemeQuery.addEventListener('change', trackColorSchemeChoice);
-    return () => colorSchemeQuery.removeEventListener('change', trackColorSchemeChoice);
+    const colorSchemeQuery = window?.matchMedia('(prefers-color-scheme: dark)');
+    if (colorSchemeQuery) {
+      // send user's initial choice
+      trackColorSchemeChoice(colorSchemeQuery);
+      colorSchemeQuery.addEventListener('change', trackColorSchemeChoice);
+    }
+    return () => {
+      if (colorSchemeQuery) {
+        colorSchemeQuery.removeEventListener('change', trackColorSchemeChoice);
+      }
+    };
   }, []);
 };

--- a/src/react/hooks.js
+++ b/src/react/hooks.js
@@ -35,7 +35,7 @@ export const useTrackColorSchemeChoice = () => {
       const preferredColorScheme = matches ? 'dark' : 'light';
       sendTrackEvent('openedx.ui.frontend-platform.prefers-color-scheme.selected', { preferredColorScheme });
     };
-    const colorSchemeQuery = window?.matchMedia('(prefers-color-scheme: dark)');
+    const colorSchemeQuery = window.matchMedia?.('(prefers-color-scheme: dark)');
     if (colorSchemeQuery) {
       // send user's initial choice
       trackColorSchemeChoice(colorSchemeQuery);

--- a/src/react/hooks.test.jsx
+++ b/src/react/hooks.test.jsx
@@ -5,11 +5,13 @@ import { sendTrackEvent } from '../analytics';
 jest.mock('../analytics');
 
 const mockAddEventListener = jest.fn();
+const mockRemoveEventListener = jest.fn();
 let matchesMock;
 
 Object.defineProperty(window, 'matchMedia', {
   value: jest.fn(() => ({
     addEventListener: mockAddEventListener,
+    removeEventListener: mockRemoveEventListener,
     matches: matchesMock,
   })),
 });
@@ -17,6 +19,7 @@ Object.defineProperty(window, 'matchMedia', {
 describe('useTrackColorSchemeChoice hook', () => {
   afterEach(() => {
     mockAddEventListener.mockClear();
+    mockRemoveEventListener.mockClear();
     sendTrackEvent.mockClear();
   });
 


### PR DESCRIPTION
**Description:**

The previous release (3.4.0) added `useTrackColorSchemeChoice`, which relies on `window.matchMedia`. However, when running tests with this version of `@edx/frontend-platform` installed in MFEs, unless `window.matchMedia` is explicitly mocked in the consuming applications, any test that relies on `AppProvider` will fail.

This PR will gracefully handle when `window.matchMedia` is missing (e.g., `window.matchMedia?.('(prefers-color-scheme: dark)')`).

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
