### PR TITLE
fix: avoid multiple segment identify calls

### DIFF
--- a/src/analytics/SegmentAnalyticsService.js
+++ b/src/analytics/SegmentAnalyticsService.js
@@ -157,6 +157,10 @@ class SegmentAnalyticsService {
    * @param {*} [traits]
    */
   identifyAuthenticatedUser(userId, traits) {
+    if (this.hasIdentifyBeenCalled) {
+      return;
+    }
+
     if (!userId) {
       throw new Error('UserId is required for identifyAuthenticatedUser.');
     }
@@ -175,6 +179,10 @@ class SegmentAnalyticsService {
    * @returns {Promise} Promise that will resolve once the document readyState is complete
    */
   identifyAnonymousUser(traits) { // eslint-disable-line no-unused-vars
+    if (this.hasIdentifyBeenCalled) {
+      return Promise.resolve();
+    }
+
     if (!this.segmentInitialized) {
       return Promise.resolve();
     }

--- a/src/analytics/interface.test.js
+++ b/src/analytics/interface.test.js
@@ -112,6 +112,30 @@ describe('Analytics', () => {
         expect(() => identifyAuthenticatedUser(null))
           .toThrowError(new Error('UserId is required for identifyAuthenticatedUser.'));
       });
+
+      it('should call segment identify once', () => {
+        const testTraits = { anything: 'Yay!' };
+        identifyAuthenticatedUser(testUserId, testTraits);
+        identifyAuthenticatedUser(testUserId, testTraits);
+
+        expect(window.analytics.identify.mock.calls.length).toBe(1);
+      });
+
+      it('should call segment identify if hasIdentifyBeenCalled is false', () => {
+        const testTraits = { anything: 'Yay!' };
+        service.hasIdentifyBeenCalled = false;
+        identifyAuthenticatedUser(testUserId, testTraits);
+
+        expect(window.analytics.identify).toHaveBeenCalled();
+      });
+
+      it('should not call segment identify if hasIdentifyBeenCalled is true', () => {
+        const testTraits = { anything: 'Yay!' };
+        service.hasIdentifyBeenCalled = true;
+        identifyAuthenticatedUser(testUserId, testTraits);
+
+        expect(window.analytics.identify).not.toHaveBeenCalled();
+      });
     });
 
     describe('analytics identifyAnonymousUser', () => {
@@ -129,6 +153,33 @@ describe('Analytics', () => {
         identifyAnonymousUser(testTraits);
 
         expect(window.analytics.reset.mock.calls.length).toBe(1);
+      });
+
+      it('should call segment reset once', () => {
+        window.analytics.user = () => ({ id: () => 1 });
+        const testTraits = { anything: 'Yay!' };
+        identifyAnonymousUser(testTraits);
+        identifyAnonymousUser(testTraits);
+
+        expect(window.analytics.reset.mock.calls.length).toBe(1);
+      });
+
+      it('should call segment reset if hasIdentifyBeenCalled is false', () => {
+        window.analytics.user = () => ({ id: () => 2 });
+        const testTraits = { anything: 'Yay!' };
+        service.hasIdentifyBeenCalled = false;
+        identifyAnonymousUser(testTraits);
+
+        expect(window.analytics.reset).toHaveBeenCalled();
+      });
+
+      it('should not call segment reset if hasIdentifyBeenCalled is true', () => {
+        window.analytics.user = () => ({ id: () => 3 });
+        const testTraits = { anything: 'Yay!' };
+        service.hasIdentifyBeenCalled = true;
+        identifyAnonymousUser(testTraits);
+
+        expect(window.analytics.reset).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
This PR adds a check to avoid multiple identify calls to the segment.

**Context:**

In Authn, a user has an anonymous user ID in all segment events until the user is authenticated. A user is moved to the welcome page after registration and we want to fire a segment identify call on the welcome page because the user is now authenticated. But the identify call is not fired until the user reloads the page manually. So we are explicitly calling `identifyAuthenticatedUser` in the welcome page so that the user has its actual user ID in all the segment events.

This works fine and identify call is fired with the user ID on the welcome page.

**Issue:**

The issue is when a user reloads the page, there are 3 identify calls being fired.

1. The automatically identify call due to reloading.
2. Our explicit identify call from `useEffect` which has `authenticatedUser` as a dependency which we get from the 
`getAuthenticatedUser` function.
3. We are also using `hydrateAuthenticatedUser` to attach some additional user attributes to authenticated User, which changes the `authenticatedUser` object causing `useEffect` to call `identifyAuthenticatedUser` again.

We want to avoid these multiple calls and we noticed that we have a `hasIdentifyBeenCalled` flag in `frontend-platform`, so we are using this flag in the `identifyAuthenticatedUser` function to avoid multiple identify calls.
