### PR TITLE
fix: fixed axios mock errros by upgrading axios-mock-adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@edx/frontend-build": "12.7.0",
         "@edx/paragon": "20.28.5",
         "@testing-library/react-hooks": "^8.0.1",
-        "axios-mock-adapter": "1.21.2",
+        "axios-mock-adapter": "^1.21.3",
         "core-js": "3.29.1",
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.7",
@@ -5165,9 +5165,9 @@
       }
     },
     "node_modules/axios-mock-adapter": {
-      "version": "1.21.2",
-      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.2.tgz",
-      "integrity": "sha512-jzyNxU3JzB2XVhplZboUcF0YDs7xuExzoRSHXPHr+UQajaGmcTqvkkUADgkVI2WkGlpZ1zZlMVdcTMU0ejV8zQ==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.21.3.tgz",
+      "integrity": "sha512-cdrQs/BqiJq4qn5EvaUUKDCaSor2j0KKW5tMtq5lqfTauxLRownBlzUNoLe+WKRoDrrXXXbtXTbmKpWFdL/NJw==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@edx/frontend-build": "12.7.0",
     "@edx/paragon": "20.28.5",
     "@testing-library/react-hooks": "^8.0.1",
-    "axios-mock-adapter": "1.21.2",
+    "axios-mock-adapter": "^1.21.3",
     "core-js": "3.29.1",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.7",


### PR DESCRIPTION
**Description:**

Fixes unit tests that were crashing due to issues in axios-mock-adapter

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
