### PR TITLE
chore: remove taffydb to resolve security vulnerability

### DIFF
--- a/docs/template/edx/README.md
+++ b/docs/template/edx/README.md
@@ -1,4 +1,4 @@
-The default template for JSDoc 3 uses: [the Taffy Database library](http://taffydb.com/) and the [Underscore Template library](http://underscorejs.org/).
+The default template for JSDoc 4 uses: the [Underscore Template library](http://underscorejs.org/).
 
 
 ## Generating Typeface Fonts

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "lodash.memoize": "4.1.2",
         "lodash.merge": "4.6.2",
         "lodash.snakecase": "4.1.1",
+        "lokijs": "^1.5.12",
         "pubsub-js": "1.9.4",
         "react-intl": "^5.25.0",
         "universal-cookie": "4.0.4"
@@ -43,7 +44,7 @@
         "enzyme": "3.11.0",
         "enzyme-adapter-react-16": "1.15.7",
         "husky": "8.0.3",
-        "jsdoc": "3.6.11",
+        "jsdoc": "^4.0.0",
         "nodemon": "2.0.21",
         "prop-types": "15.8.1",
         "react": "16.14.0",
@@ -3389,6 +3390,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
+      "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
       }
     },
     "node_modules/@newrelic/publish-sourcemap": {
@@ -13126,12 +13139,13 @@
       }
     },
     "node_modules/jsdoc": {
-      "version": "3.6.11",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.11.tgz",
-      "integrity": "sha512-8UCU0TYeIYD9KeLzEcAu2q8N/mx9O3phAGl32nmHlE0LpaJL71mMkP4d+QE5zWfNt50qheHtOZ0qoxVrsX5TUg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.0.tgz",
+      "integrity": "sha512-tzTgkklbWKrlaQL2+e3NNgLcZu3NaK2vsHRx7tyHQ+H5jcB9Gx0txSd2eJWlMC/xU1+7LQu4s58Ry0RkuaEQVg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.9.4",
+        "@jsdoc/salty": "^0.2.1",
         "@types/markdown-it": "^12.2.3",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
@@ -13144,7 +13158,6 @@
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
-        "taffydb": "2.6.2",
         "underscore": "~1.13.2"
       },
       "bin": {
@@ -13513,6 +13526,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
+    },
+    "node_modules/lokijs": {
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/lokijs/-/lokijs-1.5.12.tgz",
+      "integrity": "sha512-Q5ALD6JiS6xAUWCwX3taQmgwxyveCtIIuL08+ml0nHwT3k0S/GIFJN+Hd38b1qYIMaE5X++iqsqWVksz7SYW+Q=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -19081,12 +19099,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
       "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA==",
-      "dev": true
-    },
-    "node_modules/taffydb": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
-      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "dev": true
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.7",
     "husky": "8.0.3",
-    "jsdoc": "3.6.11",
+    "jsdoc": "^4.0.0",
     "nodemon": "2.0.21",
     "prop-types": "15.8.1",
     "react": "16.14.0",
@@ -68,6 +68,7 @@
     "lodash.memoize": "4.1.2",
     "lodash.merge": "4.6.2",
     "lodash.snakecase": "4.1.1",
+    "lokijs": "^1.5.12",
     "pubsub-js": "1.9.4",
     "react-intl": "^5.25.0",
     "universal-cookie": "4.0.4"


### PR DESCRIPTION
**Description:**

This PR replaces `taffyDB` with `lokiJS`, which resolves this [security vulnerability](https://github.com/openedx/frontend-platform/security/dependabot/48) related to taffyDB.
