### PR TITLE
fix: remove the hasIdentifyBeenCalled check and its corresponding tests

### DIFF
--- a/src/analytics/SegmentAnalyticsService.js
+++ b/src/analytics/SegmentAnalyticsService.js
@@ -157,10 +157,6 @@ class SegmentAnalyticsService {
    * @param {*} [traits]
    */
   identifyAuthenticatedUser(userId, traits) {
-    if (this.hasIdentifyBeenCalled) {
-      return;
-    }
-
     if (!userId) {
       throw new Error('UserId is required for identifyAuthenticatedUser.');
     }
@@ -179,10 +175,6 @@ class SegmentAnalyticsService {
    * @returns {Promise} Promise that will resolve once the document readyState is complete
    */
   identifyAnonymousUser(traits) { // eslint-disable-line no-unused-vars
-    if (this.hasIdentifyBeenCalled) {
-      return Promise.resolve();
-    }
-
     if (!this.segmentInitialized) {
       return Promise.resolve();
     }

--- a/src/analytics/interface.test.js
+++ b/src/analytics/interface.test.js
@@ -112,30 +112,6 @@ describe('Analytics', () => {
         expect(() => identifyAuthenticatedUser(null))
           .toThrowError(new Error('UserId is required for identifyAuthenticatedUser.'));
       });
-
-      it('should call segment identify once', () => {
-        const testTraits = { anything: 'Yay!' };
-        identifyAuthenticatedUser(testUserId, testTraits);
-        identifyAuthenticatedUser(testUserId, testTraits);
-
-        expect(window.analytics.identify.mock.calls.length).toBe(1);
-      });
-
-      it('should call segment identify if hasIdentifyBeenCalled is false', () => {
-        const testTraits = { anything: 'Yay!' };
-        service.hasIdentifyBeenCalled = false;
-        identifyAuthenticatedUser(testUserId, testTraits);
-
-        expect(window.analytics.identify).toHaveBeenCalled();
-      });
-
-      it('should not call segment identify if hasIdentifyBeenCalled is true', () => {
-        const testTraits = { anything: 'Yay!' };
-        service.hasIdentifyBeenCalled = true;
-        identifyAuthenticatedUser(testUserId, testTraits);
-
-        expect(window.analytics.identify).not.toHaveBeenCalled();
-      });
     });
 
     describe('analytics identifyAnonymousUser', () => {
@@ -153,33 +129,6 @@ describe('Analytics', () => {
         identifyAnonymousUser(testTraits);
 
         expect(window.analytics.reset.mock.calls.length).toBe(1);
-      });
-
-      it('should call segment reset once', () => {
-        window.analytics.user = () => ({ id: () => 1 });
-        const testTraits = { anything: 'Yay!' };
-        identifyAnonymousUser(testTraits);
-        identifyAnonymousUser(testTraits);
-
-        expect(window.analytics.reset.mock.calls.length).toBe(1);
-      });
-
-      it('should call segment reset if hasIdentifyBeenCalled is false', () => {
-        window.analytics.user = () => ({ id: () => 2 });
-        const testTraits = { anything: 'Yay!' };
-        service.hasIdentifyBeenCalled = false;
-        identifyAnonymousUser(testTraits);
-
-        expect(window.analytics.reset).toHaveBeenCalled();
-      });
-
-      it('should not call segment reset if hasIdentifyBeenCalled is true', () => {
-        window.analytics.user = () => ({ id: () => 3 });
-        const testTraits = { anything: 'Yay!' };
-        service.hasIdentifyBeenCalled = true;
-        identifyAnonymousUser(testTraits);
-
-        expect(window.analytics.reset).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
### Description:

This pull request reverses the earlier change where the flag `hasIdentifyBeenCalled` was added to the `identifyAuthenticatedUser` and `identifyAnonymousUser` functions, along with their respective tests. This modification proved to be ineffective in addressing the problem we faced and did not serve the intended purpose.


### Reason to revert:

The addition of a flag to the `identifyAuthenticatedUser` and `identifyAnonymousUser` functions caused a bug where the `identifyAnonymousUser` function was called with an anonymous ID on the registration page, setting the `hasIdentifyBeenCalled` flag to true. This caused the `identifyAuthenticatedUser` function was not called to perform the segment identify call after registration, as the `hasIdentifyBeenCalled` check was already true due to the previous function call. As a result, the segment identify call was not made and events were still being missed. This issue was discovered during testing, as it was not possible to test it locally, so the code had to be deployed on stage to identify the problem.

>  Reference PR #458 