### PR TITLE
feat: JavaScript file configuration of apps

### DIFF
--- a/docs/decisions/0007-javascript-file-configuration.rst
+++ b/docs/decisions/0007-javascript-file-configuration.rst
@@ -28,7 +28,7 @@ token that helps the build replace it with a string literal.
 This approach has several important limitations:
 
 - There's no way to add variables without hard-coding process.env.XXXX somewhere in the file,
-  complicating our ability to add additional application-specific configuration without explici tly
+  complicating our ability to add additional application-specific configuration without explicitly
   merging it into the configuration document after it's been created in frontend-platform.
 - The method can *only* handle strings.
 

--- a/docs/decisions/0007-javascript-file-configuration.rst
+++ b/docs/decisions/0007-javascript-file-configuration.rst
@@ -1,0 +1,111 @@
+Promote JavaScript file configuration and deprecate environment variable configuration
+======================================================================================
+
+Status
+------
+
+Draft
+
+Context
+-------
+
+Our webpack build process allows us to set environment variables on the command line or via .env
+files.  These environment variables are available in the application via ``process.env``.
+
+The implementation of this uses templatization and string interpolation to replace any instance of
+``process.env.XXXX`` with the value of the environment variable named ``XXXX``.  As an example, in our
+source code we may write::
+
+    const LMS_BASE_URL = process.env.LMS_BASE_URL;
+
+After the build process runs, the compiled source code will instead read::
+
+    const LMS_BASE_URL = 'http://localhost:18000';
+
+Put another way, `process.env` is not actually an object available at runtime, it's a templatization
+token that helps the build replace it with a string literal.
+
+This approach has several important limitations:
+
+- There's no way to add variables without hard-coding process.env.XXXX somewhere in the file,
+  complicating our ability to add additional application-specific configuration without explici tly
+  merging it into the configuration document after it's been created in frontend-platform.
+- The method can *only* handle strings.
+
+  Other data types are converted to strings::
+
+    # Build command:
+    BOOLEAN_VAR=false NULL_VAR=null NUMBER_VAR=123 npm run build
+
+    ...
+
+    // Source code:
+    const BOOLEAN_VAR = process.env.BOOLEAN_VAR;
+    const NULL_VAR = process.env.NULL_VAR;
+    const NUMBER_VAR = process.env.NUMBER_VAR;
+
+    ...
+
+    // Compiled source after the build runs:
+    const BOOLEAN_VAR = "false";
+    const NULL_VAR = "null";
+    const NUMBER_VAR = "123";
+
+  This is not good!
+
+- It makes it very difficult to supply array and object configuration variables, and unreasonable to
+  supply class or function config since we'd have to ``eval()`` them.
+
+Related to all this, frontend-platform has long hand the ability to replace the implementations of
+its analytics, auth, and logging services, but no way to actually *configure* the app with a new
+implementation.  Because of the above limitations, there's no reasonable way to configure a
+JavaScript class via environment variables.
+
+Decision
+--------
+
+For the above reasons, we will deprecate environment variable configuration in favor of JavaScript
+file configuration.
+
+This method makes use of an ``env.config.js`` file to supply configuration variables to an application::
+
+    const config = {
+      LMS_BASE_URL: 'http://localhost:18000',
+      BOOLEAN_VAR: false,
+      NULL_VAR: null,
+      NUMBER_VAR: 123
+    };
+
+    export default config;
+
+This file is imported by the frontend-build webpack build process if it exists, and expected by
+frontend-platform as part of its initialization process. If the file doesn't exist, frontend-build
+falls back to importing an empty object for backwards compatibility.  This functionality already exists
+today in frontend-build in preparation for using it here in frontend-platform.
+
+This interdependency creates a peerDependency for frontend-platform on `frontend-build v8.1.0 <frontend_build_810_>`_ or
+later.
+
+Using a JavaScript file for configuration is standard practice in the JavaScript/node community.
+Babel, webpack, eslint, Jest, etc., all accept configuration via JavaScript files (which we take
+advantage of in frontend-build), so there is ample precedent for using a .js file for configuration.
+
+In order to achieve deprecation of environment variable configuration, we will follow the
+deprecation process described in `OEP-21: Deprecation and Removal <oep21_>`_.  In addition, we will
+add build-time warnings to frontend-build indicating the deprecation of environment
+variable configuration.  Practically speaking, this will mean adjusting build processes throughout
+the community and in common tools like Tutor.
+
+Rejected Alternatives
+---------------------
+
+Another option was to use JSON files for this purpose.  This solves some of our issues (limited use
+of non-string primitive data types) but is otherwise not nearly as expressive for flexible as using
+a JavaScript file directly.  Anecdotally, in the past frontend-build used JSON versions of many of
+its configuration files (Babel, eslint, jest) but over time they were all converted to JavaScript
+files so we could express more complicated configuration needs.  Since one of the primary use cases
+and reasons we need a new configuration method is to allow developers to supply alternate implementations
+of frontend-platform's core services (analytics, logging), JSON was a effectively a non-starter.
+
+.. _oep21: https://docs.openedx.org/projects/openedx-proposals/en/latest/processes/oep-0021-proc-deprecation.html
+.. _frontend_build_810: https://github.com/openedx/frontend-build/releases/tag/v8.1.0

--- a/docs/decisions/0007-javascript-file-configuration.rst
+++ b/docs/decisions/0007-javascript-file-configuration.rst
@@ -4,7 +4,7 @@ Promote JavaScript file configuration and deprecate environment variable configu
 Status
 ------
 
-Draft
+Accepted
 
 Context
 -------

--- a/docs/decisions/0007-javascript-file-configuration.rst
+++ b/docs/decisions/0007-javascript-file-configuration.rst
@@ -9,12 +9,13 @@ Draft
 Context
 -------
 
-Our webpack build process allows us to set environment variables on the command line or via .env
-files.  These environment variables are available in the application via ``process.env``.
+Our webpack build process allows us to set environment variables on the command
+line or via .env files.  These environment variables are available in the
+application via ``process.env``.
 
-The implementation of this uses templatization and string interpolation to replace any instance of
-``process.env.XXXX`` with the value of the environment variable named ``XXXX``.  As an example, in our
-source code we may write::
+The implementation of this uses templatization and string interpolation to
+replace any instance of ``process.env.XXXX`` with the value of the environment
+variable named ``XXXX``.  As an example, in our source code we may write::
 
     const LMS_BASE_URL = process.env.LMS_BASE_URL;
 
@@ -22,14 +23,16 @@ After the build process runs, the compiled source code will instead read::
 
     const LMS_BASE_URL = 'http://localhost:18000';
 
-Put another way, `process.env` is not actually an object available at runtime, it's a templatization
-token that helps the build replace it with a string literal.
+Put another way, `process.env` is not actually an object available at runtime,
+it's a templatization token that helps the build replace it with a string
+literal.
 
 This approach has several important limitations:
 
-- There's no way to add variables without hard-coding process.env.XXXX somewhere in the file,
-  complicating our ability to add additional application-specific configuration without explicitly
-  merging it into the configuration document after it's been created in frontend-platform.
+- There's no way to add variables without hard-coding process.env.XXXX
+  somewhere in the file, complicating our ability to add additional
+  application-specific configuration without explicitly merging it into the
+  configuration document after it's been created in frontend-platform.
 - The method can *only* handle strings.
 
   Other data types are converted to strings::
@@ -53,21 +56,24 @@ This approach has several important limitations:
 
   This is not good!
 
-- It makes it very difficult to supply array and object configuration variables, and unreasonable to
-  supply class or function config since we'd have to ``eval()`` them.
+- It makes it very difficult to supply array and object configuration
+  variables, and unreasonable to supply class or function config since we'd
+  have to ``eval()`` them.
 
-Related to all this, frontend-platform has long hand the ability to replace the implementations of
-its analytics, auth, and logging services, but no way to actually *configure* the app with a new
-implementation.  Because of the above limitations, there's no reasonable way to configure a
-JavaScript class via environment variables.
+Related to all this, frontend-platform has long had the ability to replace the
+implementations of its analytics, auth, and logging services, but no way to
+actually *configure* the app with a new implementation.  Because of the above
+limitations, there's no reasonable way to configure a JavaScript class via
+environment variables.
 
 Decision
 --------
 
-For the above reasons, we will deprecate environment variable configuration in favor of JavaScript
-file configuration.
+For the above reasons, we will deprecate environment variable configuration in
+favor of JavaScript file configuration.
 
-This method makes use of an ``env.config.js`` file to supply configuration variables to an application::
+This method makes use of an ``env.config.js`` file to supply configuration
+variables to an application::
 
     const config = {
       LMS_BASE_URL: 'http://localhost:18000',
@@ -78,34 +84,61 @@ This method makes use of an ``env.config.js`` file to supply configuration varia
 
     export default config;
 
-This file is imported by the frontend-build webpack build process if it exists, and expected by
-frontend-platform as part of its initialization process. If the file doesn't exist, frontend-build
-falls back to importing an empty object for backwards compatibility.  This functionality already exists
-today in frontend-build in preparation for using it here in frontend-platform.
+This file is imported by the frontend-build webpack build process if it exists,
+and expected by frontend-platform as part of its initialization process. If the
+file doesn't exist, frontend-build falls back to importing an empty object for
+backwards compatibility.  This functionality already exists today in
+frontend-build in preparation for using it here in frontend-platform.
 
 This interdependency creates a peerDependency for frontend-platform on `frontend-build v8.1.0 <frontend_build_810_>`_ or
 later.
 
-Using a JavaScript file for configuration is standard practice in the JavaScript/node community.
-Babel, webpack, eslint, Jest, etc., all accept configuration via JavaScript files (which we take
-advantage of in frontend-build), so there is ample precedent for using a .js file for configuration.
+Using a JavaScript file for configuration is standard practice in the
+JavaScript/node community.  Babel, webpack, eslint, Jest, etc., all accept
+configuration via JavaScript files (which we take advantage of in
+frontend-build), so there is ample precedent for using a .js file for
+configuration.
 
-In order to achieve deprecation of environment variable configuration, we will follow the
-deprecation process described in `OEP-21: Deprecation and Removal <oep21_>`_.  In addition, we will
-add build-time warnings to frontend-build indicating the deprecation of environment
-variable configuration.  Practically speaking, this will mean adjusting build processes throughout
-the community and in common tools like Tutor.
+In order to achieve deprecation of environment variable configuration, we will
+follow the deprecation process described in
+`OEP-21: Deprecation and Removal <oep21_>`_. In addition, we will add
+build-time warnings to frontend-build indicating the deprecation of environment
+variable configuration.  Practically speaking, this will mean adjusting build
+processes throughout the community and in common tools like Tutor.
+
+Relationship to runtime configuration
+*************************************
+
+JavaScript file configuration is compatible with runtime MFE configuration.
+frontend-platform loads configuration in a predictable order:
+
+- environment variable config
+- optional handlers (used to merge MFE-specific config in via additional
+  process.env variables)
+- JS file config
+- runtime config
+
+In the end, runtime config wins. That said, JS file config solves some use
+cases that runtime config can't solve around extensibility and customization.
+
+In the future if we deprecate environment variable config, it's likely that
+we keep both JS file config and runtime configuration around.  JS file config
+primarily to handle extensibility, and runtime config for everything else.
+
 
 Rejected Alternatives
 ---------------------
 
-Another option was to use JSON files for this purpose.  This solves some of our issues (limited use
-of non-string primitive data types) but is otherwise not nearly as expressive for flexible as using
-a JavaScript file directly.  Anecdotally, in the past frontend-build used JSON versions of many of
-its configuration files (Babel, eslint, jest) but over time they were all converted to JavaScript
-files so we could express more complicated configuration needs.  Since one of the primary use cases
-and reasons we need a new configuration method is to allow developers to supply alternate implementations
-of frontend-platform's core services (analytics, logging), JSON was a effectively a non-starter.
+Another option was to use JSON files for this purpose.  This solves some of our
+issues (limited use of non-string primitive data types) but is otherwise not
+nearly as expressive or flexible as using a JavaScript file directly.
+Anecdotally, in the past frontend-build used JSON versions of many of
+its configuration files (Babel, eslint, jest) but over time they were all
+converted to JavaScript files so we could express more complicated
+configuration needs.  Since one of the primary use cases and reasons we need a
+new configuration method is to allow developers to supply alternate
+implementations of frontend-platform's core services (analytics, logging), JSON
+was effectively a non-starter.
 
 .. _oep21: https://docs.openedx.org/projects/openedx-proposals/en/latest/processes/oep-0021-proc-deprecation.html
 .. _frontend_build_810: https://github.com/openedx/frontend-build/releases/tag/v8.1.0

--- a/docs/decisions/0007-javascript-file-configuration.rst
+++ b/docs/decisions/0007-javascript-file-configuration.rst
@@ -113,7 +113,7 @@ JavaScript file configuration is compatible with runtime MFE configuration.
 frontend-platform loads configuration in a predictable order:
 
 - environment variable config
-- optional handlers (used to merge MFE-specific config in via additional
+- optional handlers (commonly used to merge MFE-specific config in via additional
   process.env variables)
 - JS file config
 - runtime config
@@ -124,7 +124,6 @@ cases that runtime config can't solve around extensibility and customization.
 In the future if we deprecate environment variable config, it's likely that
 we keep both JS file config and runtime configuration around.  JS file config
 primarily to handle extensibility, and runtime config for everything else.
-
 
 Rejected Alternatives
 ---------------------

--- a/env.config.js
+++ b/env.config.js
@@ -1,0 +1,8 @@
+// NOTE: This file is used by the example app and the test suite.  frontend-build expects the file
+// to be in the root of the repository.  This is not used by the actual frontend-platform library.
+// Also note that in an actual application this file would be added to .gitignore.
+const config = {
+  JS_FILE_VAR: 'JS_FILE_VAR_VALUE',
+};
+
+export default config;

--- a/env.config.js
+++ b/env.config.js
@@ -1,0 +1,8 @@
+// NOTE: This file is used by the example app.  frontend-build expects the file
+// to be in the root of the repository.  This is not used by the actual frontend-platform library.
+// Also note that in an actual application this file would be added to .gitignore.
+const config = {
+  JS_FILE_VAR: 'JS_FILE_VAR_VALUE_FOR_EXAMPLE_APP',
+};
+
+export default config;

--- a/env.config.js
+++ b/env.config.js
@@ -1,8 +1,0 @@
-// NOTE: This file is used by the example app and the test suite.  frontend-build expects the file
-// to be in the root of the repository.  This is not used by the actual frontend-platform library.
-// Also note that in an actual application this file would be added to .gitignore.
-const config = {
-  JS_FILE_VAR: 'JS_FILE_VAR_VALUE',
-};
-
-export default config;

--- a/example/ExamplePage.jsx
+++ b/example/ExamplePage.jsx
@@ -13,6 +13,7 @@ mergeConfig({
 
 ensureConfig([
   'EXAMPLE_VAR',
+  'JS_FILE_VAR',
 ], 'ExamplePage');
 
 class ExamplePage extends Component {
@@ -45,6 +46,7 @@ class ExamplePage extends Component {
         <p>{this.props.intl.formatMessage(messages['example.message'])}</p>
         {this.renderAuthenticatedUser()}
         <p>EXAMPLE_VAR env var came through: <strong>{getConfig().EXAMPLE_VAR}</strong></p>
+        <p>JS_FILE_VAR var came through: <strong>{getConfig().JS_FILE_VAR}</strong></p>
         <p>Visit <Link to="/authenticated">authenticated page</Link>.</p>
         <p>Visit <Link to="/error_example">error page</Link>.</p>
       </div>

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "peerDependencies": {
     "@edx/paragon": ">= 10.0.0 < 21.0.0",
+    "@edx/frontend-build": ">= 8.1.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -22,7 +22,7 @@
  * away.  There are two methods of supplying build-time configuration: environment variables and a
  * JavaScript file.
  *
- * ######Environment Variables
+ * ###### Environment Variables
  *
  * A set list of required config variables can be supplied as
  * command-line environment variables during the build process.

--- a/src/config.js
+++ b/src/config.js
@@ -2,10 +2,27 @@
  * #### Import members from **@edx/frontend-platform**
  *
  * The configuration module provides utilities for working with an application's configuration
- * document (ConfigDocument).  Configuration environment variables can be supplied to the
- * application in four different ways:
+ * document (ConfigDocument).  Configuration variables can be supplied to the
+ * application in four different ways.  They are applied in the following order:
  *
- * ##### Build-time Environment Variables
+ * - Build-time Configuration
+ *   - Environment Variables
+ *   - JavaScript File
+ * - Runtime Configuration
+ *
+ * Last one in wins.  Variables with the same name defined via the later methods will override any
+ * defined using an earlier method.  i.e., if a variable is defined in Runtime Configuration, that
+ * will override the same variable defined in either Build-time Configuration method (environment
+ * variables or JS file).  Configuration defined in a JS file will override environment variables.
+ *
+ * ##### Build-time Configuration
+ *
+ * Build-time configuration methods add config variables into the app when it is built by webpack.
+ * This saves the app an API call and means it has all the information it needs to initialize right
+ * away.  There are two methods of supplying build-time configuration: environment variables and a
+ * JavaScript file.
+ *
+ * ######Environment Variables
  *
  * A set list of required config variables can be supplied as
  * command-line environment variables during the build process.
@@ -19,12 +36,23 @@
  * Note that additional variables _cannot_ be supplied via this method without using the `config`
  * initialization handler.  The app won't pick them up and they'll appear `undefined`.
  *
- * ##### JavaScript File Configuration
+ * This configuration method is being deprecated in favor of JavaScript File Configuration.
  *
- * Configuration variables can be supplied in an optional file
- * named env.config.js.  This file must export either an Object containing configuration variables
- * or a function.  The function must return an Object containing configuration variables or,
- * alternately, a promise which resolves to an Object.
+ * ###### JavaScript File Configuration
+ *
+ * Configuration variables can be supplied in an optional file named env.config.js.  This file must
+ * export either an Object containing configuration variables or a function.  The function must
+ * return an Object containing configuration variables or, alternately, a promise which resolves to
+ * an Object.
+ *
+ * Using a function or async function allows the configuration to be resolved at runtime (because
+ * the function will be executed at runtime).  This is not common, and the capability is included
+ * for the sake of flexibility.
+ *
+ * JavaScript File Configuration is well-suited to extensibility use cases or component overrides,
+ * in that the configuration file can depend on any installed JavaScript module.  It is also the
+ * preferred way of doing build-time configuration if runtime configuration isn't used by your
+ * deployment of the platform.
  *
  * Exporting a config object:
  * ```
@@ -59,14 +87,19 @@
  *
  * ##### Runtime Configuration
  *
- * Configuration variables can also be supplied using the "runtime
- * configuration" method, taking advantage of the Micro-frontend Config API in edx-platform.
- * More information on this API can be found in the ADR which introduced it:
+ * Configuration variables can also be supplied using the "runtime configuration" method, taking
+ * advantage of the Micro-frontend Config API in edx-platform. More information on this API can be
+ * found in the ADR which introduced it:
  *
  * https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/mfe_config_api/docs/decisions/0001-mfe-config-api.rst
  *
  * The runtime configuration method can be enabled by supplying a MFE_CONFIG_API_URL via one of the other
  * two configuration methods above.
+ *
+ * Runtime configuration is particularly useful if you need to supply different configurations to
+ * a single deployment of a micro-frontend, for instance.  It is also a perfectly valid alternative
+ * to build-time configuration, though it introduces an additional API call to edx-platform on MFE
+ * initialization.
  *
  * ##### Initialization Config Handler
  *

--- a/src/initialize.async.function.config.test.js
+++ b/src/initialize.async.function.config.test.js
@@ -1,0 +1,44 @@
+import PubSub from 'pubsub-js';
+import { initialize } from './initialize';
+
+import {
+  logError,
+} from './logging';
+import {
+  ensureAuthenticatedUser,
+  fetchAuthenticatedUser,
+  hydrateAuthenticatedUser,
+} from './auth';
+import { getConfig } from './config';
+
+jest.mock('./logging');
+jest.mock('./auth');
+jest.mock('./analytics');
+jest.mock('./i18n');
+jest.mock('./auth/LocalForageCache');
+jest.mock('env.config.js', () => async () => new Promise((resolve) => {
+  resolve({
+    JS_FILE_VAR: 'JS_FILE_VAR_VALUE_ASYNC_FUNCTION',
+  });
+}));
+
+let config = null;
+
+describe('initialize with async function js file config', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    config = getConfig();
+    fetchAuthenticatedUser.mockReset();
+    ensureAuthenticatedUser.mockReset();
+    hydrateAuthenticatedUser.mockReset();
+    logError.mockReset();
+    PubSub.clearAllSubscriptions();
+  });
+
+  it('should initialize the app with async function javascript file configuration', async () => {
+    const messages = { i_am: 'a message' };
+    await initialize({ messages });
+
+    expect(config.JS_FILE_VAR).toEqual('JS_FILE_VAR_VALUE_ASYNC_FUNCTION');
+  });
+});

--- a/src/initialize.const.config.test.js
+++ b/src/initialize.const.config.test.js
@@ -39,5 +39,4 @@ describe('initialize with constant js file config', () => {
 
     expect(config.JS_FILE_VAR).toEqual('JS_FILE_VAR_VALUE_CONSTANT');
   });
-
 });

--- a/src/initialize.const.config.test.js
+++ b/src/initialize.const.config.test.js
@@ -1,0 +1,43 @@
+import PubSub from 'pubsub-js';
+import { initialize } from './initialize';
+
+import {
+  logError,
+} from './logging';
+import {
+  ensureAuthenticatedUser,
+  fetchAuthenticatedUser,
+  hydrateAuthenticatedUser,
+} from './auth';
+import { getConfig } from './config';
+
+jest.mock('./logging');
+jest.mock('./auth');
+jest.mock('./analytics');
+jest.mock('./i18n');
+jest.mock('./auth/LocalForageCache');
+jest.mock('env.config.js', () => ({
+  JS_FILE_VAR: 'JS_FILE_VAR_VALUE_CONSTANT',
+}));
+
+let config = null;
+
+describe('initialize with constant js file config', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    config = getConfig();
+    fetchAuthenticatedUser.mockReset();
+    ensureAuthenticatedUser.mockReset();
+    hydrateAuthenticatedUser.mockReset();
+    logError.mockReset();
+    PubSub.clearAllSubscriptions();
+  });
+
+  it('should initialize the app with javascript file configuration', async () => {
+    const messages = { i_am: 'a message' };
+    await initialize({ messages });
+
+    expect(config.JS_FILE_VAR).toEqual('JS_FILE_VAR_VALUE_CONSTANT');
+  });
+
+});

--- a/src/initialize.function.config.test.js
+++ b/src/initialize.function.config.test.js
@@ -1,0 +1,42 @@
+import PubSub from 'pubsub-js';
+import { initialize } from './initialize';
+
+import {
+  logError,
+} from './logging';
+import {
+  ensureAuthenticatedUser,
+  fetchAuthenticatedUser,
+  hydrateAuthenticatedUser,
+} from './auth';
+import { getConfig } from './config';
+
+jest.mock('./logging');
+jest.mock('./auth');
+jest.mock('./analytics');
+jest.mock('./i18n');
+jest.mock('./auth/LocalForageCache');
+jest.mock('env.config.js', () => () => ({
+  JS_FILE_VAR: 'JS_FILE_VAR_VALUE_FUNCTION',
+}));
+
+let config = null;
+
+describe('initialize with function js file config', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    config = getConfig();
+    fetchAuthenticatedUser.mockReset();
+    ensureAuthenticatedUser.mockReset();
+    hydrateAuthenticatedUser.mockReset();
+    logError.mockReset();
+    PubSub.clearAllSubscriptions();
+  });
+
+  it('should initialize the app with javascript file configuration', async () => {
+    const messages = { i_am: 'a message' };
+    await initialize({ messages });
+
+    expect(config.JS_FILE_VAR).toEqual('JS_FILE_VAR_VALUE_FUNCTION');
+  });
+});

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -46,6 +46,15 @@
  */
 
 import { createBrowserHistory, createMemoryHistory } from 'history';
+/*
+This 'env.config' package is a special 'magic' alias in our webpack configuration in frontend-build.
+It points at an `env.config.js` file in the root of an MFE's repository if it exists and falls back
+to an empty object `{}` if the file doesn't exist.  This acts like an 'optional' import, in a sense.
+Note that the env.config.js file in frontend-platform's root directory is NOT used by the actual
+initialization code, it's just there for the test suite and example application.
+*/
+import envConfig from 'env.config'; // eslint-disable-line import/no-unresolved
+
 import {
   publish,
 } from './pubSub';
@@ -131,13 +140,32 @@ export async function auth(requireUser, hydrateUser) {
     hydrateAuthenticatedUser();
   }
 }
+
+/**
+ * Set or overrides configuration via an env.config.js file in the consuming application.
+ * This env.config.js is loaded at runtime and must export one of two things:
+ *
+ * - An object which will be merged into the application config via `mergeConfig`.
+ * - A function which returns an object which will be merged into the application config via
+ * `mergeConfig`.  This function can return a promise.
+ */
+async function jsFileConfig() {
+  let config = {};
+  if (typeof envConfig === 'function') {
+    config = await envConfig();
+  } else {
+    config = envConfig;
+  }
+
+  mergeConfig(config);
+}
+
 /*
  * Set or overrides configuration through an API.
  * This method allows runtime configuration.
  * Set a basic configuration when an error happen and allow initError and display the ErrorPage.
  */
-
-export async function runtimeConfig() {
+async function runtimeConfig() {
   try {
     const { MFE_CONFIG_API_URL, APP_ID } = getConfig();
 
@@ -264,6 +292,7 @@ export async function initialize({
 
     // Configuration
     await handlers.config();
+    await jsFileConfig();
     await runtimeConfig();
     publish(APP_CONFIG_INITIALIZED);
 
@@ -271,15 +300,24 @@ export async function initialize({
       config: getConfig(),
     });
 
+    // This allows us to replace the implementations of the logging, analytics, and auth services
+    // based on keys in the ConfigDocument.  The JavaScript File Configuration method is the only
+    // one capable of supplying an alternate implementation since it can import other modules.
+    // If a service wasn't supplied we fall back to the default parameters on the initialize
+    // function signature.
+    const loggingServiceImpl = getConfig().loggingService || loggingService;
+    const analyticsServiceImpl = getConfig().analyticsService || analyticsService;
+    const authServiceImpl = getConfig().authService || authService;
+
     // Logging
-    configureLogging(loggingService, {
+    configureLogging(loggingServiceImpl, {
       config: getConfig(),
     });
     await handlers.logging();
     publish(APP_LOGGING_INITIALIZED);
 
     // Authentication
-    configureAuth(authService, {
+    configureAuth(authServiceImpl, {
       loggingService: getLoggingService(),
       config: getConfig(),
       middleware: authMiddleware,
@@ -289,7 +327,7 @@ export async function initialize({
     publish(APP_AUTH_INITIALIZED);
 
     // Analytics
-    configureAnalytics(analyticsService, {
+    configureAnalytics(analyticsServiceImpl, {
       config: getConfig(),
       loggingService: getLoggingService(),
       httpClient: getAuthenticatedHttpClient(),

--- a/src/initialize.test.js
+++ b/src/initialize.test.js
@@ -279,6 +279,13 @@ describe('initialize', () => {
     expect(overrideHandlers.initError).toHaveBeenCalledWith(new Error('uhoh!'));
   });
 
+  it('should initialize the app with javascript file configuration', async () => {
+    const messages = { i_am: 'a message' };
+    await initialize({ messages });
+
+    expect(config.JS_FILE_VAR).toEqual('JS_FILE_VAR_VALUE');
+  });
+
   it('should initialize the app with runtime configuration', async () => {
     config.MFE_CONFIG_API_URL = 'http://localhost:18000/api/mfe/v1/config';
     config.APP_ID = 'auth';

--- a/src/initialize.test.js
+++ b/src/initialize.test.js
@@ -279,13 +279,6 @@ describe('initialize', () => {
     expect(overrideHandlers.initError).toHaveBeenCalledWith(new Error('uhoh!'));
   });
 
-  it('should initialize the app with javascript file configuration', async () => {
-    const messages = { i_am: 'a message' };
-    await initialize({ messages });
-
-    expect(config.JS_FILE_VAR).toEqual('JS_FILE_VAR_VALUE');
-  });
-
   it('should initialize the app with runtime configuration', async () => {
     config.MFE_CONFIG_API_URL = 'http://localhost:18000/api/mfe/v1/config';
     config.APP_ID = 'auth';


### PR DESCRIPTION
This adds the ability to configure an application via an env.config.js file rather than environment variables or .env files.  This mechanism is much more flexible and powerful than environment variables as described in the associated ADR.

It also improves documentation around how to configure applications, providing more detail on the various methods.

Finally, it allows the logging, analytics, and auth services to be configured via the configuration document now that we can supply an alternate implementation in an env.config.js file.  This allows configuration of these services without forking the MFE.

It doesn't remove the ability to supply a service implementation via the `initialize()` function's arguments since that would technically be a breaking change and it could conceivably be in use in forks today.  At a later date we could choose to remove that mechanism.

fixes https://github.com/openedx/wg-frontend/issues/11

**Description:**

Describe what this pull request changes, and why. Include implications for people using this change.

**Merge checklist:**

- [x] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [x] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
