### PR TITLE
fix: force refresh jwt token on ensureAuthenticatedUser

### DIFF
--- a/src/auth/AxiosJwtAuthService.js
+++ b/src/auth/AxiosJwtAuthService.js
@@ -250,7 +250,7 @@ class AxiosJwtAuthService {
    * @returns {Promise<UserData>}
    */
   async ensureAuthenticatedUser(redirectUrl = this.config.BASE_URL) {
-    await this.fetchAuthenticatedUser();
+    await this.fetchAuthenticatedUser({ forceRefresh: true });
 
     if (this.getAuthenticatedUser() === null) {
       const isRedirectFromLoginPage = global.document.referrer


### PR DESCRIPTION
[VAN-1371](https://2u-internal.atlassian.net/browse/VAN-1371)

**Description:**

This PR adds a `forceRefresh: true` option while calling `fetchAuthenticatedUser` inside `ensureAuthenticatedUser` to forcefully refresh the JWT token from the backend.

**Why this was needed?**

When a user resets his password through account settings (accounts MFE), the user is redirected to the login page because his session is invalidated at the backend. But he is not logged out of other MFEs such as learner home even if the user refreshes the page. But if the user tries to do some API call to the backend for example user tries to **unenroll** a course in the learner's home MFE, a 403 forbidden response is returned from the backend because he is unauthenticated at the backend and the course is not unenrolled.

The reason is on refreshing the JWT token is not refreshed from the backend instead the token is fetched from cookies and decoded to ensure authentication at the frontend. 

**Effect on users:**

- Users stay authenticated on the frontend but are unable to perform certain actions because they are unauthenticated at the backend.
- This is inconsistent in that the user is unauthenticated at the backend but authenticated at frontend. 

This fix will make sure to un-authenticate the user on frontend when the user is unauthenticated on the backend.

**Please let us know if you think this change will have any negative effects**