### PR TITLE
feat: set userId custom attribute for logging service

### DIFF
--- a/src/auth/AxiosJwtAuthService.js
+++ b/src/auth/AxiosJwtAuthService.js
@@ -234,8 +234,13 @@ class AxiosJwtAuthService {
         administrator: decodedAccessToken.administrator,
         name: decodedAccessToken.name,
       });
+      // Sets userId as a custom attribute that will be included with all subsequent log messages.
+      // Very helpful for debugging.
+      this.loggingService.setCustomAttribute('userId', decodedAccessToken.user_id);
     } else {
       this.setAuthenticatedUser(null);
+      // Intentionally not setting `userId` in the logging service here because it would be useful
+      // to know the previously logged in user for debugging refresh issues.
     }
 
     return this.getAuthenticatedUser();

--- a/src/auth/AxiosJwtAuthService.test.jsx
+++ b/src/auth/AxiosJwtAuthService.test.jsx
@@ -7,6 +7,7 @@ import AxiosJwtAuthService from './AxiosJwtAuthService';
 const mockLoggingService = {
   logInfo: jest.fn(),
   logError: jest.fn(),
+  setCustomAttribute: jest.fn(),
 };
 
 const authOptions = {
@@ -204,6 +205,7 @@ beforeEach(() => {
   };
   mockLoggingService.logInfo.mockReset();
   mockLoggingService.logError.mockReset();
+  mockLoggingService.setCustomAttribute.mockReset();
   service.getCsrfTokenService().clearCsrfTokenCache();
   axiosMock.onGet('/unauthorized').reply(401);
   axiosMock.onGet('/forbidden').reply(403);
@@ -861,6 +863,7 @@ describe('fetchAuthenticatedUser', () => {
     setJwtTokenRefreshResponseTo(200, jwtTokens.valid.encoded);
     return service.fetchAuthenticatedUser().then((authenticatedUserAccessToken) => {
       expect(authenticatedUserAccessToken).toEqual(jwtTokens.valid.formatted);
+      expect(mockLoggingService.setCustomAttribute).toHaveBeenCalledWith('userId', jwtTokens.valid.formatted.userId);
       expectSingleCallToJwtTokenRefresh();
     });
   });
@@ -878,6 +881,7 @@ describe('fetchAuthenticatedUser', () => {
     setJwtTokenRefreshResponseTo(401, null);
     return service.fetchAuthenticatedUser({ forceRefresh: true }).then((authenticatedUserAccessToken) => {
       expect(authenticatedUserAccessToken).toEqual(null);
+      expect(mockLoggingService.setCustomAttribute).not.toHaveBeenCalled();
       expectSingleCallToJwtTokenRefresh();
     });
   });

--- a/src/logging/MockLoggingService.js
+++ b/src/logging/MockLoggingService.js
@@ -19,6 +19,13 @@ class MockLoggingService {
    * @memberof MockLoggingService
    */
   logError = jest.fn();
+
+  /**
+   * Implemented as a jest.fn()
+   *
+   * @memberof MockLoggingService
+   */
+  setCustomAttribute = jest.fn();
 }
 
 export default MockLoggingService;

--- a/src/logging/NewRelicLoggingService.js
+++ b/src/logging/NewRelicLoggingService.js
@@ -23,7 +23,7 @@ const pageActionNameIgnoredError = 'IGNORED_ERROR';
 
 function sendPageAction(actionName, message, customAttributes) {
   if (process.env.NODE_ENV === 'development') {
-    console.log(message, customAttributes); // eslint-disable-line
+    console.log(actionName, message, customAttributes); // eslint-disable-line
   }
   if (window && typeof window.newrelic !== 'undefined') {
     window.newrelic.addPageAction(actionName, { message, ...customAttributes });

--- a/src/logging/NewRelicLoggingService.js
+++ b/src/logging/NewRelicLoggingService.js
@@ -41,6 +41,16 @@ function sendError(error, customAttributes) {
   }
 }
 
+function setCustomAttribute(name, value) {
+  if (process.env.NODE_ENV === 'development') {
+    console.log(name, value); // eslint-disable-line
+  }
+  if (window && typeof window.newrelic !== 'undefined') {
+    // https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/setcustomattribute/
+    window.newrelic.setCustomAttribute(name, value);
+  }
+}
+
 /**
  * The NewRelicLoggingService is a concrete implementation of the logging service interface that
  * sends messages to NewRelic that can be seen in NewRelic Browser and NewRelic Insights. When in
@@ -67,7 +77,8 @@ function sendError(error, customAttributes) {
  * ```
  *
  * You can also add your own custom metrics as an additional argument, or see the code to find
- * other standard custom attributes.
+ * other standard custom attributes. By default, userId is added (via setCustomAttribute) for logged
+ * in users via the auth service (AuthAxiosJwtService).
  *
  * Requires the NewRelic Browser JavaScript snippet.
  *
@@ -156,5 +167,15 @@ export default class NewRelicLoggingService {
       /*  error! */
       sendError(errorStringOrObject, allCustomAttributes);
     }
+  }
+
+  /**
+   * Sets a custom attribute that will be included with all subsequent log messages.
+   *
+   * @param {string} name
+   * @param {string|number|null} value
+   */
+  setCustomAttribute(name, value) {
+    setCustomAttribute(name, value);
   }
 }

--- a/src/logging/NewRelicLoggingService.js
+++ b/src/logging/NewRelicLoggingService.js
@@ -26,6 +26,7 @@ function sendPageAction(actionName, message, customAttributes) {
     console.log(actionName, message, customAttributes); // eslint-disable-line
   }
   if (window && typeof window.newrelic !== 'undefined') {
+    // https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/addpageaction/
     window.newrelic.addPageAction(actionName, { message, ...customAttributes });
   }
 }
@@ -35,6 +36,7 @@ function sendError(error, customAttributes) {
     console.error(error, customAttributes); // eslint-disable-line
   }
   if (window && typeof window.newrelic !== 'undefined') {
+    // https://docs.newrelic.com/docs/browser/new-relic-browser/browser-apis/noticeerror/
     window.newrelic.noticeError(fixErrorLength(error), customAttributes);
   }
 }

--- a/src/logging/NewRelicLoggingService.test.js
+++ b/src/logging/NewRelicLoggingService.test.js
@@ -3,6 +3,7 @@ import NewRelicLoggingService, { MAX_ERROR_LENGTH } from './NewRelicLoggingServi
 global.newrelic = {
   addPageAction: jest.fn(),
   noticeError: jest.fn(),
+  setCustomAttribute: jest.fn(),
 };
 
 let service = null;
@@ -137,6 +138,17 @@ describe('NewRelicLoggingService', () => {
       };
       service.logError(error);
       expect(global.newrelic.noticeError).toHaveBeenCalledWith(expectedError, undefined);
+    });
+  });
+
+  describe('setCustomAttribute', () => {
+    beforeEach(() => {
+      global.newrelic.setCustomAttribute.mockReset();
+    });
+
+    it('calls New Relic client with name and value', () => {
+      service.setCustomAttribute('foo', 'bar');
+      expect(global.newrelic.setCustomAttribute).toHaveBeenCalledWith('foo', 'bar');
     });
   });
 

--- a/src/logging/interface.js
+++ b/src/logging/interface.js
@@ -72,6 +72,16 @@ export function logError(errorStringOrObject, customAttributes) {
 }
 
 /**
+ * Sets a custom attribute that will be included with all subsequent log messages.
+ *
+ * @param {string} name
+ * @param {string|number|null} value
+ */
+export function setCustomAttribute(name, value) {
+  return service.setCustomAttribute(name, value);
+}
+
+/**
  *
  * @throws {Error} Thrown if the logging service has not yet been configured via {@link configure}.
  * @returns {LoggingService}


### PR DESCRIPTION
**Description:**

Adding setCustomAttribute to the logging service’s interface and implementing it in the NewRelicLoggingService.  Also using that in the auth service in order to set the userId as a custom attribute for all logged in users.

Also adding some more detail on code comments.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
