### PR TITLE
Add frontend-build 12.9.0-alpha.1 in peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "universal-cookie": "4.0.4"
   },
   "peerDependencies": {
-    "@edx/frontend-build": ">= 8.1.0",
+    "@edx/frontend-build": ">= 8.1.0 || ^12.9.0-alpha.1",
     "@edx/paragon": ">= 10.0.0 < 21.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0 || ^17.0.0",


### PR DESCRIPTION
**Description:**

The `frontend-platform@4.5.0` [PR](https://github.com/openedx/frontend-platform/pull/474) includes `frontend-build` as a peer dependency. Since `frontend-app-admin-portal` is installed with `frontend-build@12.9.0-alpha.1`, I have added `frontend-build 12.9.0-alpha.1` in the Peer Dependency to satisfy `frontend-app-admin-portal`.


**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
