### PR TITLE
feat: fallback component as prop for ErrorBoundary

### DIFF
--- a/src/react/ErrorBoundary.jsx
+++ b/src/react/ErrorBoundary.jsx
@@ -11,7 +11,7 @@ import ErrorPage from './ErrorPage';
  * @memberof module:React
  * @extends {Component}
  */
-export default class ErrorBoundary extends Component {
+class ErrorBoundary extends Component {
   constructor(props) {
     super(props);
     this.state = { hasError: false };
@@ -28,17 +28,20 @@ export default class ErrorBoundary extends Component {
 
   render() {
     if (this.state.hasError) {
-      return <ErrorPage />;
+      return this.props.fallbackComponent || <ErrorPage />;
     }
-
     return this.props.children;
   }
 }
 
 ErrorBoundary.propTypes = {
   children: PropTypes.node,
+  fallbackComponent: PropTypes.node,
 };
 
 ErrorBoundary.defaultProps = {
   children: null,
+  fallbackComponent: undefined,
 };
+
+export default ErrorBoundary;

--- a/src/react/ErrorBoundary.test.jsx
+++ b/src/react/ErrorBoundary.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ErrorBoundary from './ErrorBoundary';
+import ErrorPage from './ErrorPage';
 import { initializeMockApp } from '..';
 
 describe('ErrorBoundary', () => {
@@ -53,5 +54,31 @@ describe('ErrorBoundary', () => {
         stack: expect.stringContaining('ExplodingComponent'),
       }),
     );
+  });
+  it('should render the fallback component when an error occurs', () => {
+    function FallbackComponent() {
+      return <div>Oops, something went wrong!</div>;
+    }
+    function ComponentError() {
+      throw new Error('An error occurred during the click event!');
+    }
+    const wrapper = mount(
+      <ErrorBoundary fallbackComponent={<FallbackComponent />}>
+        <ComponentError />
+      </ErrorBoundary>,
+    );
+    expect(wrapper.contains(<FallbackComponent />)).toBe(true);
+  });
+
+  it('should render the ErrorPage fallbackComponent is null', () => {
+    function ComponentError() {
+      throw new Error('An error occurred during the click event!');
+    }
+    const wrapper = mount(
+      <ErrorBoundary fallbackComponent={null}>
+        <ComponentError />
+      </ErrorBoundary>,
+    );
+    expect(wrapper.contains(<ErrorPage />)).toBe(true);
   });
 });


### PR DESCRIPTION
**Description:**

The `ErrorBoundary` component becomes more flexible with the ability to pass the component you want to render in place of just the `ErrorPage` component. This feature is similar to the [react-error-boundary](https://github.com/bvaughn/react-error-boundary.git) library.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
