### PR TITLE
feat: expand support for Paragon v21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-build": ">= 8.1.0 || ^12.9.0-alpha.1",
-        "@edx/paragon": ">= 10.0.0 < 21.0.0",
+        "@edx/paragon": ">= 10.0.0 < 22.0.0",
         "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "@edx/frontend-build": ">= 8.1.0 || ^12.9.0-alpha.1",
-    "@edx/paragon": ">= 10.0.0 < 21.0.0",
+    "@edx/paragon": ">= 10.0.0 < 22.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0",


### PR DESCRIPTION
**Description:**

Paragon v21 was released as a breaking a11y change. This PR ensures the peer dependency allows consumers to install v21 without running into peer dependency errors.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
