### PR TITLE
fix: fixing and exporting mergeMessages()

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -104,6 +104,7 @@ export {
   getMessages,
   isRtl,
   handleRtl,
+  mergeMessages,
   LOCALE_CHANGED,
   LOCALE_TOPIC,
 } from './lib';

--- a/src/i18n/lib.js
+++ b/src/i18n/lib.js
@@ -236,12 +236,15 @@ const optionsShape = {
 /**
  *
  *
- * @param {Array} [messagesArray=[]]
+ * @param {Object} newMessages
  * @returns {Object}
  * @memberof module:Internationalization
  */
-export function mergeMessages(messagesArray = []) {
-  return Array.isArray(messagesArray) ? merge({}, ...messagesArray) : {};
+export function mergeMessages(newMessages) {
+  const msgs = Array.isArray(newMessages) ? merge({}, ...newMessages) : newMessages;
+  messages = merge(messages, msgs);
+
+  return messages;
 }
 
 /**
@@ -262,7 +265,7 @@ export function configure(options) {
   loggingService = options.loggingService;
   // eslint-disable-next-line prefer-destructuring
   config = options.config;
-  messages = Array.isArray(options.messages) ? mergeMessages(options.messages) : options.messages;
+  messages = Array.isArray(options.messages) ? merge({}, ...options.messages) : options.messages;
 
   if (config.ENVIRONMENT !== 'production') {
     Object.keys(messages).forEach((key) => {

--- a/src/i18n/lib.test.js
+++ b/src/i18n/lib.test.js
@@ -250,9 +250,40 @@ describe('lib', () => {
 });
 
 describe('mergeMessages', () => {
+  it('should merge objects', () => {
+    configure({
+      loggingService: { logError: jest.fn() },
+      config: {
+        ENVIRONMENT: 'production',
+        LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+      },
+      messages: {
+        ar: { message: 'ar-hah' },
+      },
+    });
+    const result = mergeMessages({ en: { foo: 'bar' }, de: { buh: 'baz' }, jp: { gah: 'wut' }});
+    expect(result).toEqual({
+      ar: { message: 'ar-hah' },
+      en: { foo: 'bar' },
+      de: { buh: 'baz' },
+      jp: { gah: 'wut' },
+    });
+  });
+
   it('should merge objects from an array', () => {
+    configure({
+      loggingService: { logError: jest.fn() },
+      config: {
+        ENVIRONMENT: 'production',
+        LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+      },
+      messages: {
+        ar: { message: 'ar-hah' },
+      },
+    });
     const result = mergeMessages([{ foo: 'bar' }, { buh: 'baz' }, { gah: 'wut' }]);
     expect(result).toEqual({
+      ar: { message: 'ar-hah' },
       foo: 'bar',
       buh: 'baz',
       gah: 'wut',
@@ -260,6 +291,17 @@ describe('mergeMessages', () => {
   });
 
   it('should merge nested objects from an array', () => {
+    configure({
+      loggingService: { logError: jest.fn() },
+      config: {
+        ENVIRONMENT: 'production',
+        LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+      },
+      messages: {
+        en: { init: 'initial' },
+        es: { init: 'inicial' },
+      },
+    });
     const messages = [
       {
         en: { hello: 'hello' },
@@ -274,10 +316,12 @@ describe('mergeMessages', () => {
     const result = mergeMessages(messages);
     expect(result).toEqual({
       en: {
+        init: 'initial',
         hello: 'hello',
         goodbye: 'goodbye',
       },
       es: {
+        init: 'inicial',
         hello: 'hola',
         goodbye: 'adiós',
       },
@@ -285,8 +329,32 @@ describe('mergeMessages', () => {
   });
 
   it('should return an empty object if no messages', () => {
+    configure({
+      loggingService: { logError: jest.fn() },
+      config: {
+        ENVIRONMENT: 'production',
+        LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+      },
+      messages: {},
+    });
     expect(mergeMessages(undefined)).toEqual({});
     expect(mergeMessages(null)).toEqual({});
     expect(mergeMessages([])).toEqual({});
+    expect(mergeMessages({})).toEqual({});
+  });
+
+  it('should return the original object if no messages', () => {
+    configure({
+      loggingService: { logError: jest.fn() },
+      config: {
+        ENVIRONMENT: 'production',
+        LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+      },
+      messages: { en: { hello: 'world ' } },
+    });
+    expect(mergeMessages(undefined)).toEqual({ en: { hello: 'world ' } });
+    expect(mergeMessages(null)).toEqual({ en: { hello: 'world ' } });
+    expect(mergeMessages([])).toEqual({ en: { hello: 'world ' } });
+    expect(mergeMessages({})).toEqual({ en: { hello: 'world ' } });
   });
 });

--- a/src/i18n/lib.test.js
+++ b/src/i18n/lib.test.js
@@ -261,7 +261,7 @@ describe('mergeMessages', () => {
         ar: { message: 'ar-hah' },
       },
     });
-    const result = mergeMessages({ en: { foo: 'bar' }, de: { buh: 'baz' }, jp: { gah: 'wut' }});
+    const result = mergeMessages({ en: { foo: 'bar' }, de: { buh: 'baz' }, jp: { gah: 'wut' } });
     expect(result).toEqual({
       ar: { message: 'ar-hah' },
       en: { foo: 'bar' },


### PR DESCRIPTION
Fixed and exported the internal function `mergeMessages()` and refactored unit-tests to cover the new behavior. Previously this method would return an `object` identical to the one passed in (or an `object` version of an `array` passed in) and ignore/clobber any messages previously supplied. The new version fixes this function to actually merge new messages with existing ones. 

The method was never exported outside the package and the only internal use was in the `configure()` method which is refactored in this PR to use `lodash.merge()` directly. 
 
These changes support [OEP-65](https://github.com/openedx/open-edx-proposals/blob/426f6e09ffe615e77aa9205281d77012385a08d4/oeps/architectural-decisions/oep-XXXX-modular-micro-frontend-domains.rst#id1) and the related work in the repository `frontend-app-shell` which uses the [Piral framework](https://piral.io/) to federate MFEs. 

With existing MFE's which are deployed and run independently, there is never a need to merge messages into frontend-platform after initialization is completed. However, with federated MFEs, they need the ability to append new messages to those already loaded. This change supports this requirement. 