### PR TITLE
chore: add manual-publish.yml Github Action workflow

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -1,0 +1,47 @@
+name: Manual Publish
+on: 
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        description: NPM distribution tag to use for the backported release (npm publish --tag <tag>)
+jobs:
+  release:
+    name: Manual Publish
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Setup Nodejs Env
+      run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ env.NODE_VER }}
+    - name: Install dependencies
+      run: npm ci
+    - name: Validate package-lock.json changes
+      run: make validate-no-uncommitted-package-lock-changes
+    - name: Lint
+      run: npm run lint
+    - name: Test
+      run: npm run test
+    - name: i18n_extract
+      run: npm run i18n_extract
+    - name: Coverage
+      uses: codecov/codecov-action@v2
+    - name: Build
+      run: npm run build
+    # NPM expects to be authenticated for publishing. This step will fail CI if NPM is not authenticated
+    - name: Check NPM authentication
+      run: |
+        echo "//registry.npmjs.org/:_authToken=${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}" >> .npmrc
+        npm whoami
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}
+      # `npm publish` relies on version specified in package.json file
+      run: npm publish --tag ${{github.event.inputs.tag}} # e.g., old-version


### PR DESCRIPTION
**Description:**

Adds the `manual-publish.yml` GitHub Action workflow to be able to backport changes to previous versions of frontend-platform.

See this document for more details: https://openedx.atlassian.net/wiki/spaces/FEDX/pages/3755868171/How+to+backport+a+change+to+a+previous+version+with+semantic-release+for+JS+libraries

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
