### PR TITLE
chore: remove `validate-no-uncommitted-package-lock-changes` from manual-publish.yml

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -22,8 +22,6 @@ jobs:
         node-version: ${{ env.NODE_VER }}
     - name: Install dependencies
       run: npm ci
-    - name: Validate package-lock.json changes
-      run: make validate-no-uncommitted-package-lock-changes
     - name: Lint
       run: npm run lint
     - name: Test

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,7 @@ docs-watch:
 
 docs-lint:
 	./node_modules/.bin/documentation lint src
+
+validate-no-uncommitted-package-lock-changes:
+	# Checking for package-lock.json changes...
+	git diff --exit-code package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,3 @@ docs-watch:
 
 docs-lint:
 	./node_modules/.bin/documentation lint src
-
-validate-no-uncommitted-package-lock-changes:
-	# Checking for package-lock.json changes...
-	git diff --exit-code package-lock.json


### PR DESCRIPTION
**Description:**

Running the `manual-publish.yml` workflow file failed due to missing `validate-no-uncommitted-package-lock-changes` Make target: https://github.com/openedx/frontend-platform/actions/runs/6101546207/job/16558102918

Removes `validate-no-uncommitted-package-lock-changes` from manual-publish.yml as the Makefile in this repo does not specify that Makefile target. The `manual-publish.yml` file was largely copy/pasted from frontend-component-footer-edx which _does_ have that Makefile target.

Opting to remove the workflow step to `validate-no-uncommitted-package-lock-changes` rather than adding the Makefile target given we don't get this in any of the other workflow files for this repo today.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
