### PR TITLE
chore: remove i18n_extract from manual-publish.yml

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -28,8 +28,6 @@ jobs:
       run: npm run lint
     - name: Test
       run: npm run test
-    - name: i18n_extract
-      run: npm run i18n_extract
     - name: Coverage
       uses: codecov/codecov-action@v2
     - name: Build


### PR DESCRIPTION
**Description:**

Also carried over from copy/paste of another repo's `manual-publish.yml` file. frontend-platform has no need for the `i18n_extract` step, so this PR removes it from the workflow.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
