### PR TITLE
fix: updated react-redux peerDependency to resolve CI failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",
-        "react-redux": "^8.1.1",
+        "react-redux": "^^7.1.1 || ^8.1.1",
         "react-router-dom": "^6.0.0",
         "redux": "^4.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0",
-    "react-redux": "^8.1.1",
+    "react-redux": "^7.1.1 || ^8.1.1",
     "react-router-dom": "^6.0.0",
     "redux": "^4.0.4"
   }


### PR DESCRIPTION
## Description:
`react-redux` peerDependency was updated in [#549 ](https://github.com/openedx/frontend-platform/pull/549)causing CI failure for its consumers. Since the public API (`<Provider>`, `connect`, `useSelector`/`useDispatch`) remains unchanged and for most use-cases applications using v7 would work with v8 (apart from some rare API like `connectAdvanced` which have been removed), peerDependency for `react-redux` was updated in order to prevent any dependency issues for consumers.  
