### PR TITLE
Jlc/parser to know path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {
   convertKeyNames,
   getQueryParameters,
   ensureDefinedConfig,
+  parseURL,
 } from './utils';
 export {
   APP_TOPIC,

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ export {
   getQueryParameters,
   ensureDefinedConfig,
   parseURL,
+  getPath,
 } from './utils';
 export {
   APP_TOPIC,

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -54,7 +54,7 @@ Note that the env.config.js file in frontend-platform's root directory is NOT us
 initialization code, it's just there for the test suite and example application.
 */
 import envConfig from 'env.config'; // eslint-disable-line import/no-unresolved
-
+import { getPath } from './utils';
 import {
   publish,
 } from './pubSub';
@@ -99,7 +99,7 @@ import configureCache from './auth/LocalForageCache';
  */
 export const history = (typeof window !== 'undefined')
   ? createBrowserHistory({
-    basename: getConfig().PUBLIC_PATH,
+    basename: getPath(getConfig().PUBLIC_PATH),
   }) : createMemoryHistory();
 
 /**

--- a/src/initialize.test.js
+++ b/src/initialize.test.js
@@ -1,4 +1,5 @@
 import PubSub from 'pubsub-js';
+import { createBrowserHistory } from 'history';
 import {
   APP_PUBSUB_INITIALIZED,
   APP_CONFIG_INITIALIZED,
@@ -37,6 +38,7 @@ jest.mock('./auth');
 jest.mock('./analytics');
 jest.mock('./i18n');
 jest.mock('./auth/LocalForageCache');
+jest.mock('history');
 
 let config = null;
 const newConfig = {
@@ -349,5 +351,14 @@ describe('initialize', () => {
     expect(ensureAuthenticatedUser).not.toHaveBeenCalled();
     expect(hydrateAuthenticatedUser).not.toHaveBeenCalled();
     expect(logError).not.toHaveBeenCalled();
+  });
+});
+
+describe('history', () => {
+  it('browser history called by default path', async () => {
+    // import history from initialize;
+    expect(createBrowserHistory).toHaveBeenCalledWith({
+      basename: '/',
+    });
   });
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -123,6 +123,27 @@ export function convertKeyNames(object, nameMap) {
 }
 
 /**
+ * Given a string URL return an element that has been parsed via href.
+ * This element has the possibility to return different part of the URL.
+  parser.protocol; // => "http:"
+  parser.hostname; // => "example.com"
+  parser.port;     // => "3000"
+  parser.pathname; // => "/pathname/"
+  parser.search;   // => "?search=test"
+  parser.hash;     // => "#hash"
+  parser.host;     // => "example.com:3000"
+ * https://gist.github.com/jlong/2428561
+ *
+ * @param {string}
+ * @returns {Object}
+ */
+export function parseURL(url) {
+  const parser = document.createElement('a');
+  parser.href = url;
+  return parser;
+}
+
+/**
  * *Deprecated*: A method which converts the supplied query string into an object of
  * key-value pairs and returns it.  Defaults to the current query string - should perform like
  * [window.searchParams](https://developer.mozilla.org/en-US/docs/Web/API/URL/searchParams)

--- a/src/utils.js
+++ b/src/utils.js
@@ -144,6 +144,17 @@ export function parseURL(url) {
 }
 
 /**
+ * Given a string URL return the path of the URL
+ *
+ *
+ * @param {string}
+ * @returns {string}
+ */
+export function getPath(url) {
+  return parseURL(url).pathname;
+}
+
+/**
  * *Deprecated*: A method which converts the supplied query string into an object of
  * key-value pairs and returns it.  Defaults to the current query string - should perform like
  * [window.searchParams](https://developer.mozilla.org/en-US/docs/Web/API/URL/searchParams)

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -3,6 +3,7 @@ import {
   camelCaseObject,
   snakeCaseObject,
   convertKeyNames,
+  parseURL,
   getQueryParameters,
 } from '.';
 
@@ -111,5 +112,43 @@ describe('getQueryParameters', () => {
       foo: 'bar',
       baz: '1',
     });
+  });
+});
+
+describe('ParseURL', () => {
+  const testURL = 'http://example.com:3000/pathname/?search=test#hash';
+  const parsedURL = parseURL(testURL);
+  it('String URL is correctly parsed', () => {
+    expect(parsedURL.toString()).toEqual(testURL);
+    expect(parsedURL.href).toEqual(testURL);
+    expect(typeof (parsedURL)).toEqual('object');
+  });
+
+  it('should return protocol from URL', () => {
+    expect(parsedURL.protocol).toEqual('http:');
+  });
+
+  it('should return hostname from URL', () => {
+    expect(parsedURL.hostname).toEqual('example.com');
+  });
+
+  it('should return port from URL', () => {
+    expect(parsedURL.port).toEqual('3000');
+  });
+
+  it('should return pathname from URL', () => {
+    expect(parsedURL.pathname).toEqual('/pathname/');
+  });
+
+  it('should return search rom URL', () => {
+    expect(parsedURL.search).toEqual('?search=test');
+  });
+
+  it('should return hash from URL', () => {
+    expect(parsedURL.hash).toEqual('#hash');
+  });
+
+  it('should return host from URL', () => {
+    expect(parsedURL.host).toEqual('example.com:3000');
   });
 });

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -4,6 +4,7 @@ import {
   snakeCaseObject,
   convertKeyNames,
   parseURL,
+  getPath,
   getQueryParameters,
 } from '.';
 
@@ -150,5 +151,43 @@ describe('ParseURL', () => {
 
   it('should return host from URL', () => {
     expect(parsedURL.host).toEqual('example.com:3000');
+  });
+});
+
+describe('getPath', () => {
+  it('Path is retrieved with full url', () => {
+    const testURL = 'http://example.com:3000/pathname/?search=test#hash';
+
+    expect(getPath(testURL)).toEqual('/pathname/');
+  });
+
+  it('Path is retrieved with only path', () => {
+    const testURL = '/learning/';
+
+    expect(getPath(testURL)).toEqual('/learning/');
+  });
+
+  it('Path is retrieved without protocol', () => {
+    const testURL = '//example.com:3000/accounts/';
+
+    expect(getPath(testURL)).toEqual('/accounts/');
+  });
+
+  it('Path is retrieved with base `/`', () => {
+    const testURL = '/';
+
+    expect(getPath(testURL)).toEqual('/');
+  });
+
+  it('Path is retrieved without port', () => {
+    const testURL = 'https://example.com/accounts/';
+
+    expect(getPath(testURL)).toEqual('/accounts/');
+  });
+
+  it('Path is retrieved without CDN shape', () => {
+    const testURL = 'https://d20blt6w1kfasr.cloudfront.net/learning/';
+
+    expect(getPath(testURL)).toEqual('/learning/');
   });
 });


### PR DESCRIPTION
# Description:
This a response to the suggestion of the  fix due  error with `PUBLIC_PATH`. Because webpack complete URLS and not only paths. For eg for cases like CDN builts.
The details are more explained in the following [PR](https://github.com/openedx/frontend-build/pull/398
) due is recommended to have compatibility and support of webpack.
https://github.com/openedx/frontend-build/pull/398#issuecomment-1733757994

### Commit purposes

[feat: add parser url function to utils](https://github.com/openedx/frontend-platform/commit/e1fa60ace3b70c1f019b91cbef929c17e53666ed)
[feat: add getPath function for PUBLIC_PATH](https://github.com/openedx/frontend-platform/commit/f842f985fc8f5f6352ab1570b418997efcf19800) 

This adds a function to get a path from a string URL from utils.
Also, the function is implemented to the history module. In order to match with URLS as webpack allow.(CDN).
Tests were developed for different shapes of string urls with path.
A basic test is also added for the base case in the history variable for the initialize
with a base case of PUBLIC_PATH=`/`.
## Merge checklist: ##

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
