### PR TITLE
fix: href property issue in gatsby build

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -138,9 +138,13 @@ export function convertKeyNames(object, nameMap) {
  * @returns {Object}
  */
 export function parseURL(url) {
-  const parser = document?.createElement('a');
-  parser.href = url;
-  return parser;
+  if (typeof document !== 'undefined') {
+    const parser = document.createElement('a');
+    parser.href = url;
+    return parser;
+  }
+
+  return {};
 }
 
 /**
@@ -151,7 +155,7 @@ export function parseURL(url) {
  * @returns {string}
  */
 export function getPath(url) {
-  return parseURL(url).pathname;
+  return typeof document !== 'undefined' ? parseURL(url)?.pathname : '';
 }
 
 /**

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -119,6 +119,16 @@ describe('getQueryParameters', () => {
 describe('ParseURL', () => {
   const testURL = 'http://example.com:3000/pathname/?search=test#hash';
   const parsedURL = parseURL(testURL);
+  let originalDocument;
+
+  beforeEach(() => {
+    originalDocument = global.document;
+  });
+
+  afterEach(() => {
+    global.document = originalDocument;
+  });
+
   it('String URL is correctly parsed', () => {
     expect(parsedURL.toString()).toEqual(testURL);
     expect(parsedURL.href).toEqual(testURL);
@@ -151,6 +161,12 @@ describe('ParseURL', () => {
 
   it('should return host from URL', () => {
     expect(parsedURL.host).toEqual('example.com:3000');
+  });
+
+  it('should return empty object in case of document being undefined', () => {
+    delete global.document;
+
+    expect(parseURL(testURL)).toEqual({});
   });
 });
 


### PR DESCRIPTION
**Description:**

This PR fixes the following `href` property issue in gatsby build:

<img width="662" alt="Screenshot 2023-10-13 at 3 59 55 PM" src="https://github.com/openedx/frontend-platform/assets/88369802/3ec248ff-3ef5-400e-b80d-ac40128205a0">


**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
