### PR TITLE
fix: bumped formatjs packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.1.0",
-        "@formatjs/intl-pluralrules": "4.3.3",
-        "@formatjs/intl-relativetimeformat": "10.0.1",
+        "@formatjs/intl-pluralrules": "5.2.7",
+        "@formatjs/intl-relativetimeformat": "11.2.7",
         "axios": "0.27.2",
         "axios-cache-interceptor": "0.10.7",
         "form-urlencoded": "4.1.4",
@@ -26,7 +26,7 @@
         "lodash.merge": "4.6.2",
         "lodash.snakecase": "4.1.1",
         "pubsub-js": "1.9.4",
-        "react-intl": "^6.4.0",
+        "react-intl": "^6.5.1",
         "universal-cookie": "4.0.4"
       },
       "bin": {
@@ -2599,12 +2599,12 @@
       }
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.11.4.tgz",
-      "integrity": "sha512-EBikYFp2JCdIfGEb5G9dyCkTGDmC57KSHhRQOC3aYxoPWVZvfWCDjZwkGYHN7Lis/fmuWl906bnNTJifDQ3sXw==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz",
+      "integrity": "sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==",
       "dependencies": {
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
+        "@formatjs/intl-localematcher": "0.4.2",
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
@@ -2625,23 +2625,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@formatjs/icu-messageformat-parser/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz",
-      "integrity": "sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.4.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.2.tgz",
-      "integrity": "sha512-BGdtJFmaNJy5An/Zan4OId/yR9Ih1OojFjcduX/xOvq798OgWSyDtd6Qd5jqJXwJs1ipe4Fxu9+cshic5Ox2tA==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@formatjs/icu-skeleton-parser": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.6.2.tgz",
@@ -2651,32 +2634,15 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@formatjs/icu-skeleton-parser/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz",
-      "integrity": "sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.4.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.2.tgz",
-      "integrity": "sha512-BGdtJFmaNJy5An/Zan4OId/yR9Ih1OojFjcduX/xOvq798OgWSyDtd6Qd5jqJXwJs1ipe4Fxu9+cshic5Ox2tA==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@formatjs/intl": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.9.4.tgz",
-      "integrity": "sha512-hY0UlbDz8jY12RkQtkzxe3OfUmsIcUcsvVYyr1TFue6oTrUHqpkmYLdQ626V3BCSLc90EZDXdvmsPfMd3hTcYQ==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.9.5.tgz",
+      "integrity": "sha512-WEdEv8Jf2nKBErTK4MJ2xCesUJVHH9iunXzfHzZo4tnn2NSj48g04FNH9w17XDpEbj9KEM39fLkwBz7ay/ErPQ==",
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.17.2",
         "@formatjs/fast-memoize": "2.2.0",
         "@formatjs/icu-messageformat-parser": "2.7.0",
-        "@formatjs/intl-displaynames": "6.6.0",
+        "@formatjs/intl-displaynames": "6.6.1",
         "@formatjs/intl-listformat": "7.5.0",
         "intl-messageformat": "10.5.4",
         "tslib": "^2.4.0"
@@ -2691,29 +2657,12 @@
       }
     },
     "node_modules/@formatjs/intl-displaynames": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.6.0.tgz",
-      "integrity": "sha512-bskUou9boZOzTqI8JdNCNkDavXf8uWWz/6NG1og/XJKpn4zsfiLdQ9EYKhVe/CfbCjlSyieJYn7/NztdoprHjw==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.6.1.tgz",
+      "integrity": "sha512-TIPaDu0SlwJUXlIyeSL9052jrUC4QviLnvUEJ53Ldc3Q4nZJnT2wD8NHIroTOYX9lgp5m3BeTlhpRcsnuExDkA==",
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.17.2",
         "@formatjs/intl-localematcher": "0.4.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz",
-      "integrity": "sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.4.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl-displaynames/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.2.tgz",
-      "integrity": "sha512-BGdtJFmaNJy5An/Zan4OId/yR9Ih1OojFjcduX/xOvq798OgWSyDtd6Qd5jqJXwJs1ipe4Fxu9+cshic5Ox2tA==",
-      "dependencies": {
         "tslib": "^2.4.0"
       }
     },
@@ -2727,65 +2676,31 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz",
-      "integrity": "sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.4.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl-listformat/node_modules/@formatjs/intl-localematcher": {
+    "node_modules/@formatjs/intl-localematcher": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.2.tgz",
       "integrity": "sha512-BGdtJFmaNJy5An/Zan4OId/yR9Ih1OojFjcduX/xOvq798OgWSyDtd6Qd5jqJXwJs1ipe4Fxu9+cshic5Ox2tA==",
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.2.25.tgz",
-      "integrity": "sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/@formatjs/intl-pluralrules": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-4.3.3.tgz",
-      "integrity": "sha512-NLZN8gf2qLpCuc0m565IbKLNUarEGOzk0mkdTkE4XTuNCofzoQTurW6lL3fmDlneAoYl2FiTdHa5q4o2vZF50g==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-pluralrules/-/intl-pluralrules-5.2.7.tgz",
+      "integrity": "sha512-KmLGzj8VUOhMjlFP0uEOfEgH9xkRAhDNBVmsVGZnE2EIsbpVG0GDG6DHuqnyC0KYXy7UfU/XuE0H1Bo+Mr35DQ==",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/intl-relativetimeformat": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-10.0.1.tgz",
-      "integrity": "sha512-AABPQtPjFilXegQsnmVHrSlzjFNUffAEk5DgowY6b7WSwDI7g2W6QgW903/lbZ58emhphAbgHdtKeUBXqTiLpw==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.11.4",
-        "@formatjs/intl-localematcher": "0.2.25",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz",
-      "integrity": "sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==",
-      "dependencies": {
+        "@formatjs/ecma402-abstract": "1.17.2",
         "@formatjs/intl-localematcher": "0.4.2",
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@formatjs/intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.2.tgz",
-      "integrity": "sha512-BGdtJFmaNJy5An/Zan4OId/yR9Ih1OojFjcduX/xOvq798OgWSyDtd6Qd5jqJXwJs1ipe4Fxu9+cshic5Ox2tA==",
+    "node_modules/@formatjs/intl-relativetimeformat": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-11.2.7.tgz",
+      "integrity": "sha512-Faf71hROcX8SkqnuqG9KSXano4FP3xiqaeeGmK7ii8cvsMh8xAIVpQaBaXEMI1GvJIZPVlor7rUVdf4286Cz2w==",
       "dependencies": {
+        "@formatjs/ecma402-abstract": "1.17.2",
+        "@formatjs/intl-localematcher": "0.4.2",
         "tslib": "^2.4.0"
       }
     },
@@ -10366,23 +10281,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/intl-messageformat/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz",
-      "integrity": "sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.4.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.2.tgz",
-      "integrity": "sha512-BGdtJFmaNJy5An/Zan4OId/yR9Ih1OojFjcduX/xOvq798OgWSyDtd6Qd5jqJXwJs1ipe4Fxu9+cshic5Ox2tA==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -15389,14 +15287,14 @@
       }
     },
     "node_modules/react-intl": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.5.0.tgz",
-      "integrity": "sha512-ZnBYFlFUU1ivhvWBA87XJLAr9nR8yeC1/83e6AL7yiHbWH7xQE7tyMyIyw6or78EvU9Hx8Sh8LUDC4bGrNxXOA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.5.1.tgz",
+      "integrity": "sha512-mKxfH7GV5P4dJcQmbq/xU8FVBl//xRudXgS5r1Gt62NEr+T8pnzQZZ2th1jP5BQ+Ne/3kS3uYpFcynj5KyXVhg==",
       "dependencies": {
         "@formatjs/ecma402-abstract": "1.17.2",
         "@formatjs/icu-messageformat-parser": "2.7.0",
-        "@formatjs/intl": "2.9.4",
-        "@formatjs/intl-displaynames": "6.6.0",
+        "@formatjs/intl": "2.9.5",
+        "@formatjs/intl-displaynames": "6.6.1",
         "@formatjs/intl-listformat": "7.5.0",
         "@types/hoist-non-react-statics": "^3.3.1",
         "@types/react": "16 || 17 || 18",
@@ -15412,23 +15310,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz",
-      "integrity": "sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.4.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/react-intl/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.2.tgz",
-      "integrity": "sha512-BGdtJFmaNJy5An/Zan4OId/yR9Ih1OojFjcduX/xOvq798OgWSyDtd6Qd5jqJXwJs1ipe4Fxu9+cshic5Ox2tA==",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
   },
   "dependencies": {
     "@cospired/i18n-iso-languages": "4.1.0",
-    "@formatjs/intl-pluralrules": "4.3.3",
-    "@formatjs/intl-relativetimeformat": "10.0.1",
+    "@formatjs/intl-pluralrules": "5.2.7",
+    "@formatjs/intl-relativetimeformat": "11.2.7",
     "axios": "0.27.2",
     "axios-cache-interceptor": "0.10.7",
     "form-urlencoded": "4.1.4",
@@ -70,7 +70,7 @@
     "lodash.merge": "4.6.2",
     "lodash.snakecase": "4.1.1",
     "pubsub-js": "1.9.4",
-    "react-intl": "^6.4.0",
+    "react-intl": "^6.5.1",
     "universal-cookie": "4.0.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
**Description:**

- Bumped `@formatjs/intl-pluralrules` & `@formatjs/intl-relativetimeformat` major version 
**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
