### PR TITLE
fix: PUBLIC_PATH issue for test cases

### DIFF
--- a/src/initialize.js
+++ b/src/initialize.js
@@ -99,7 +99,7 @@ import configureCache from './auth/LocalForageCache';
  */
 export const history = (typeof window !== 'undefined')
   ? createBrowserHistory({
-    basename: getPath(getConfig().PUBLIC_PATH),
+    basename: getPath(getConfig()?.PUBLIC_PATH),
   }) : createMemoryHistory();
 
 /**
@@ -112,7 +112,7 @@ export const history = (typeof window !== 'undefined')
  * as an ENV variable in the Docker file, and we read it here from that configuration so that it
  * can be passed into a Router later.
  */
-export const basename = getPath(getConfig().PUBLIC_PATH);
+export const basename = getPath(getConfig()?.PUBLIC_PATH);
 
 /**
  * The default handler for the initialization lifecycle's `initError` phase.  Logs the error to the


### PR DESCRIPTION
**Description:**

We have observed that in the test cases where `getConfig()` is mocked, test cases are failing because they can't seem to find `PUBLIC_PATH`.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
