### PR TITLE
fix: add fa, fa-ir locales in mockMessages

### DIFF
--- a/src/testing/mockMessages.js
+++ b/src/testing/mockMessages.js
@@ -5,6 +5,8 @@
 const messages = {
   ar: {},
   'es-419': {},
+  fa: {},
+  'fa-ir': {},
   fr: {},
   'zh-cn': {},
   ca: {},


### PR DESCRIPTION
**Description:**
Locale missing console warnings for `fa`, `fa-ir` are raised while running test cases. Same locales warnings are raised in many MFEs. Such as Discussions, Course-authoring.
<img width="1062" alt="Screenshot 2023-12-01 at 10 16 36 PM" src="https://github.com/openedx/frontend-platform/assets/79941147/540a6a34-ce5c-47ca-937a-548022fd3ece">
<img width="682" alt="Screenshot 2023-12-01 at 10 53 10 PM" src="https://github.com/openedx/frontend-platform/assets/79941147/666aa8d7-55c0-4742-b200-f8374d078137">


**Merge checklist:**
- [ ✅] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ✅] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [✅ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**
- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
