### PR TITLE
fix(ci): specify semantic release version that is compatible with node 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm run build
 
       - name: Release to npm/Github
-        run: npx semantic-release
+        run: npx semantic-release@22
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEMANTIC_RELEASE_NPM_TOKEN }}


### PR DESCRIPTION
**Description:**

semantic-release [version 23](https://github.com/semantic-release/semantic-release/releases/tag/v23.0.0) includes the following breaking change:
* support for node v18 has been dropped and the minimum for v20 is now v20.8.1

This pins the release workflow to version 22 until we move away from node 18.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
