### PR TITLE
chore: bump and support paragon v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/browserslist-config": "1.2.0",
         "@openedx/frontend-build": "13.0.27",
-        "@openedx/paragon": "21.13.1",
+        "@openedx/paragon": "22.0.0",
         "@testing-library/jest-dom": "6.2.0",
         "@testing-library/react": "12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
@@ -56,7 +56,7 @@
       },
       "peerDependencies": {
         "@openedx/frontend-build": ">= 13.0.15",
-        "@openedx/paragon": "^21.5.7",
+        "@openedx/paragon": ">= 21.5.7",
         "prop-types": "^15.7.2",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",
@@ -5891,9 +5891,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "21.13.1",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-21.13.1.tgz",
-      "integrity": "sha512-sLL+Z3ZWIRM6x+OrKZV0S7/SQpEcSeRcDm7E3FzhsnAWudsJCTELvSW+84uy/8dwV7mJhttsBPqQEtNafbCyYA==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.0.0.tgz",
+      "integrity": "sha512-2tD5SEu6kNf2Llop/FylqTI87mlG0jaeAhGiX57bABcHZ/cDParCxX/unPiui6LCfdrDhghjVBKD3U2+Qn6Wag==",
       "dev": true,
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "@openedx/frontend-build": ">= 13.0.15",
-    "@openedx/paragon": ">= 21.5.7",
+    "@openedx/paragon": ">= 21.5.7 < 23.0.0",
     "prop-types": "^15.7.2",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/browserslist-config": "1.2.0",
     "@openedx/frontend-build": "13.0.27",
-    "@openedx/paragon": "21.13.1",
+    "@openedx/paragon": "22.0.0",
     "@testing-library/jest-dom": "6.2.0",
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "@openedx/frontend-build": ">= 13.0.15",
-    "@openedx/paragon": "^21.5.7",
+    "@openedx/paragon": ">= 21.5.7",
     "prop-types": "^15.7.2",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0",


### PR DESCRIPTION
**Description:**

Paragon v22 was released. The current peer dependencies in package.json won't allow consumers to upgrade to Paragon v22 until explicit support for the new version is added to package.json.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
