### PR TITLE
feat: extract translations for atlas pull | FC-0012

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .vscode
 coverage
 dist
+src/i18n/transifex_input.json
 node_modules
 /docs/api
 .env.private
+/temp/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,12 @@
 # Documentation CLI usage: https://github.com/documentationjs/documentation/blob/master/docs/USAGE.md
 
+i18n = ./src/i18n
+transifex_input = $(i18n)/transifex_input.json
+transifex_utils = $(i18n)/scripts/transifex-utils.js
+
+# This directory must match .babelrc .
+transifex_temp = ./temp/babel-plugin-formatjs
+
 doc_command = ./node_modules/.bin/documentation build src -g -c ./docs/documentation.config.yml -f md -o ./docs/_API-body.md --sort-order alpha
 cat_docs_command = cat ./docs/_API-header.md ./docs/_API-body.md > ./docs/API.md
 
@@ -24,3 +31,19 @@ docs-watch:
 
 docs-lint:
 	./node_modules/.bin/documentation lint src
+
+
+.PHONY: requirements
+requirements:  ## install ci requirements
+	npm ci
+
+i18n.extract:
+	# Pulling display strings from .jsx files into .json files...
+	rm -rf $(transifex_temp)
+	npm run-script i18n_extract
+
+i18n.concat:
+	# Gathering JSON messages into one file...
+	$(transifex_utils) $(transifex_temp) $(transifex_input)
+
+extract_translations: | requirements i18n.extract i18n.concat

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "docs": "jsdoc -c jsdoc.json",
     "docs-watch": "nodemon -w src -w docs/template -w README.md -e js,jsx --exec npm run docs",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx .",
+    "i18n_extract": "fedx-scripts formatjs extract",
     "snapshot": "fedx-scripts jest --updateSnapshot",
     "start": "fedx-scripts webpack-dev-server --progress",
     "test": "fedx-scripts jest --coverage",


### PR DESCRIPTION
Allow MFEs and others to use this repo translations via [openedx-translations](https://github.com/openedx/openedx-translations) GitHub repository.


## TODO

 - [x] Add openedx-translations PR: https://github.com/openedx/openedx-translations/pull/3556
 - [x] Test in my fork for extraction: https://github.com/Zeit-Labs/openedx-translations/commit/c84aee0fc12c44eeeb43d81aac2bc99ec3138a61

## Refs

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
