### PR TITLE
core: convert i18n data imports to import syntax

### DIFF
--- a/src/i18n/countries.js
+++ b/src/i18n/countries.js
@@ -1,6 +1,20 @@
 /* eslint-disable import/extensions */
 import COUNTRIES, { langs as countryLangs } from 'i18n-iso-countries';
 
+import arLocale from 'i18n-iso-countries/langs/ar.json';
+import enLocale from 'i18n-iso-countries/langs/en.json';
+import esLocale from 'i18n-iso-countries/langs/es.json';
+import frLocale from 'i18n-iso-countries/langs/fr.json';
+import zhLocale from 'i18n-iso-countries/langs/zh.json';
+import caLocale from 'i18n-iso-countries/langs/ca.json';
+import heLocale from 'i18n-iso-countries/langs/he.json';
+import idLocale from 'i18n-iso-countries/langs/id.json';
+import koLocale from 'i18n-iso-countries/langs/ko.json';
+import plLocale from 'i18n-iso-countries/langs/pl.json';
+import ptLocale from 'i18n-iso-countries/langs/pt.json';
+import ruLocale from 'i18n-iso-countries/langs/ru.json';
+import ukLocale from 'i18n-iso-countries/langs/uk.json';
+
 import { getPrimaryLanguageSubtag } from './lib';
 
 /*
@@ -11,20 +25,20 @@ import { getPrimaryLanguageSubtag } from './lib';
  * TODO: When we start dynamically loading translations only for the current locale, change this.
  */
 
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ar.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/en.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/es.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/fr.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/zh.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ca.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/he.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/id.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ko.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/pl.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/pt.json'));
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/ru.json'));
-// COUNTRIES.registerLocale(require('i18n-iso-countries/langs/th.json')); // Doesn't exist in lib.
-COUNTRIES.registerLocale(require('i18n-iso-countries/langs/uk.json'));
+COUNTRIES.registerLocale(arLocale);
+COUNTRIES.registerLocale(enLocale);
+COUNTRIES.registerLocale(esLocale);
+COUNTRIES.registerLocale(frLocale);
+COUNTRIES.registerLocale(zhLocale);
+COUNTRIES.registerLocale(caLocale);
+COUNTRIES.registerLocale(heLocale);
+COUNTRIES.registerLocale(idLocale);
+COUNTRIES.registerLocale(koLocale);
+COUNTRIES.registerLocale(plLocale);
+COUNTRIES.registerLocale(ptLocale);
+COUNTRIES.registerLocale(ruLocale);
+// COUNTRIES.registerLocale(thLocale); // Doesn't exist in lib.
+COUNTRIES.registerLocale(ukLocale);
 
 /**
  * Provides a lookup table of country IDs to country names for the current locale.

--- a/src/i18n/languages.js
+++ b/src/i18n/languages.js
@@ -1,6 +1,21 @@
 /* eslint-disable import/extensions */
 import LANGUAGES, { langs as languageLangs } from '@cospired/i18n-iso-languages';
 
+// import arLocale from '@cospired/i18n-iso-languages/langs/ar.json';
+import enLocale from '@cospired/i18n-iso-languages/langs/en.json';
+import esLocale from '@cospired/i18n-iso-languages/langs/es.json';
+import frLocale from '@cospired/i18n-iso-languages/langs/fr.json';
+// import zhLocale from '@cospired/i18n-iso-languages/langs/zh.json';
+// import caLocale from '@cospired/i18n-iso-languages/langs/ca.json';
+// import heLocale from '@cospired/i18n-iso-languages/langs/he.json';
+// import idLocale from '@cospired/i18n-iso-languages/langs/id.json';
+// import koLocale from '@cospired/i18n-iso-languages/langs/ko.json';
+import plLocale from '@cospired/i18n-iso-languages/langs/pl.json';
+import ptLocale from '@cospired/i18n-iso-languages/langs/pt.json';
+// import ruLocale from '@cospired/i18n-iso-languages/langs/ru.json';
+// import thLocale from '@cospired/i18n-iso-languages/langs/th.json';
+// import ukLocale from '@cospired/i18n-iso-languages/langs/uk.json';
+
 import { getPrimaryLanguageSubtag } from './lib';
 
 /*
@@ -14,20 +29,20 @@ import { getPrimaryLanguageSubtag } from './lib';
  * been a while, go check and see if that's changed!
  */
 
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/ar.json'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/en.json'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/es.json'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/fr.json'));
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/zh.json'));
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/ca.json'));
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/he.json'));
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/id.json'));
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/ko.json'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/pl.json'));
-LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/pt.json'));
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/ru.json'));
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/th.json'));
-// LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/uk.json'));
+// LANGUAGES.registerLocale(arLocale);
+LANGUAGES.registerLocale(enLocale);
+LANGUAGES.registerLocale(esLocale);
+LANGUAGES.registerLocale(frLocale);
+// LANGUAGES.registerLocale(zhLocale);
+// LANGUAGES.registerLocale(caLocale);
+// LANGUAGES.registerLocale(heLocale);
+// LANGUAGES.registerLocale(idLocale);
+// LANGUAGES.registerLocale(koLocale);
+LANGUAGES.registerLocale(plLocale);
+LANGUAGES.registerLocale(ptLocale);
+// LANGUAGES.registerLocale(ruLocale);
+// LANGUAGES.registerLocale(thLocale);
+// LANGUAGES.registerLocale(ukLocale);
 
 /**
  * Provides a lookup table of language IDs to language names for the current locale.


### PR DESCRIPTION
This changes a few stray usages of Node's `require()` syntax to the modern ES6 module `import` syntax. It should have basically no effect, except that it makes the code more compatible with a wider range of tools. For example, building an MFE with Vite instead of Webpack requires this change.