### PR TITLE
chore: remove core-js and regenerator-runtime

### DIFF
--- a/example/index.jsx
+++ b/example/index.jsx
@@ -1,6 +1,3 @@
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "@testing-library/react": "12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
         "axios-mock-adapter": "^1.22.0",
-        "core-js": "3.37.1",
         "husky": "8.0.3",
         "jest-environment-jsdom": "29.7.0",
         "jsdoc": "^4.0.0",
@@ -52,8 +51,7 @@
         "react-dom": "17.0.2",
         "react-redux": "^8.1.1",
         "react-router-dom": "^6.6.1",
-        "redux": "4.2.1",
-        "regenerator-runtime": "0.14.1"
+        "redux": "4.2.1"
       },
       "peerDependencies": {
         "@openedx/frontend-build": ">= 14.0.0",
@@ -7849,18 +7847,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
-    },
-    "node_modules/core-js": {
-      "version": "3.37.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.37.1.tgz",
-      "integrity": "sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/core-js-compat": {
       "version": "3.37.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/react-hooks": "^8.0.1",
     "axios-mock-adapter": "^1.22.0",
-    "core-js": "3.37.1",
     "husky": "8.0.3",
     "jest-environment-jsdom": "29.7.0",
     "jsdoc": "^4.0.0",
@@ -51,8 +50,7 @@
     "react-dom": "17.0.2",
     "react-redux": "^8.1.1",
     "react-router-dom": "^6.6.1",
-    "redux": "4.2.1",
-    "regenerator-runtime": "0.14.1"
+    "redux": "4.2.1"
   },
   "dependencies": {
     "@cospired/i18n-iso-languages": "4.2.0",

--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -1,6 +1,4 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
 import '@testing-library/jest-dom';
 
 // These configuration values are usually set in webpack's EnvironmentPlugin however


### PR DESCRIPTION
`core-js` and `regenerator-runtime` are marked as a development dependencies (for the test suites), but the tests actually pass fine without them. I think they should just be removed.

Context: they are compatibility layers for older browsers/runtimes, and aren't needed in 2024.

