### PR TITLE
feat: make redux and react-redux truly optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,14 @@
         "react-redux": "^7.1.1 || ^8.1.1",
         "react-router-dom": "^6.0.0",
         "redux": "^4.0.4"
+      },
+      "peerDependenciesMeta": {
+        "react-redux": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -82,5 +82,13 @@
     "react-redux": "^7.1.1 || ^8.1.1",
     "react-router-dom": "^6.0.0",
     "redux": "^4.0.4"
+  },
+  "peerDependenciesMeta": {
+    "redux": {
+      "optional": true
+    },
+    "react-redux": {
+      "optional": true
+    }
   }
 }

--- a/src/react/AppProvider.test.jsx
+++ b/src/react/AppProvider.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createStore } from 'redux';
-import { render, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import AppProvider from './AppProvider';
 import { initialize } from '../initialize';
 
@@ -48,7 +48,7 @@ describe('AppProvider', () => {
     });
   });
 
-  it('should render its children with a router', async () => {
+  it('should render its children with a router', () => {
     const component = (
       <AppProvider store={createStore(state => state)}>
         <div className="child">Child One</div>
@@ -57,18 +57,16 @@ describe('AppProvider', () => {
     );
 
     const wrapper = render(component);
-    await waitFor(() => {
-      const list = wrapper.container.querySelectorAll('div.child');
-      expect(list.length).toEqual(2);
-      expect(list[0].textContent).toEqual('Child One');
-      expect(list[1].textContent).toEqual('Child Two');
-    });
+    const list = wrapper.container.querySelectorAll('div.child');
+    expect(list.length).toEqual(2);
+    expect(list[0].textContent).toEqual('Child One');
+    expect(list[1].textContent).toEqual('Child Two');
     expect(wrapper.getByTestId('browser-router')).toBeInTheDocument();
     const reduxProvider = wrapper.getByTestId('redux-provider');
     expect(reduxProvider).toBeInTheDocument();
   });
 
-  it('should render its children without a router', async () => {
+  it('should render its children without a router', () => {
     const component = (
       <AppProvider store={createStore(state => state)} wrapWithRouter={false}>
         <div className="child">Child One</div>
@@ -77,18 +75,16 @@ describe('AppProvider', () => {
     );
 
     const wrapper = render(component);
-    await waitFor(() => {
-      const list = wrapper.container.querySelectorAll('div.child');
-      expect(list.length).toEqual(2);
-      expect(list[0].textContent).toEqual('Child One');
-      expect(list[1].textContent).toEqual('Child Two');
-    });
+    const list = wrapper.container.querySelectorAll('div.child');
+    expect(list.length).toEqual(2);
+    expect(list[0].textContent).toEqual('Child One');
+    expect(list[1].textContent).toEqual('Child Two');
     expect(wrapper.queryByTestId('browser-router')).not.toBeInTheDocument();
     const reduxProvider = wrapper.getByTestId('redux-provider');
     expect(reduxProvider).toBeInTheDocument();
   });
 
-  it('should skip redux Provider if not given a store', async () => {
+  it('should skip redux Provider if not given a store', () => {
     const component = (
       <AppProvider>
         <div className="child">Child One</div>
@@ -97,12 +93,10 @@ describe('AppProvider', () => {
     );
 
     const wrapper = render(component);
-    await waitFor(() => {
-      const list = wrapper.container.querySelectorAll('div.child');
-      expect(list.length).toEqual(2);
-      expect(list[0].textContent).toEqual('Child One');
-      expect(list[1].textContent).toEqual('Child Two');
-    });
+    const list = wrapper.container.querySelectorAll('div.child');
+    expect(list.length).toEqual(2);
+    expect(list[0].textContent).toEqual('Child One');
+    expect(list[1].textContent).toEqual('Child Two');
 
     const reduxProvider = wrapper.queryByTestId('redux-provider');
     expect(reduxProvider).not.toBeInTheDocument();

--- a/src/react/OptionalReduxProvider.jsx
+++ b/src/react/OptionalReduxProvider.jsx
@@ -1,16 +1,54 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Provider } from 'react-redux';
+
+function useProvider(store) {
+  const [Provider, setProvider] = useState(null);
+  useEffect(() => {
+    if (!store) {
+      setProvider(() => ({ children: c }) => c);
+      return;
+    }
+    if (process.env.NODE_ENV === 'test') {
+      // In test environments, load react-redux synchronously to avoid async state updates.
+      try {
+        // eslint-disable-next-line global-require
+        const module = require('react-redux');
+        setProvider(() => module.Provider);
+      } catch {
+        setProvider(() => ({ children: c }) => c);
+      }
+    } else {
+      // In production, load react-redux dynamically.
+      import('react-redux')
+        .then((module) => {
+          setProvider(() => module.Provider);
+        })
+        .catch(() => {
+          setProvider(() => ({ children: c }) => c);
+        });
+    }
+  }, [store]);
+  return Provider;
+}
 
 /**
  * @memberof module:React
  * @param {Object} props
  */
 export default function OptionalReduxProvider({ store = null, children }) {
+  const Provider = useProvider(store);
+
+  // If the Provider is not loaded yet, we return null to avoid rendering issues
+  if (!Provider) {
+    return null;
+  }
+
+  // If the store is null, we return the children directly as no Provider is needed
   if (store === null) {
     return children;
   }
 
+  // If the Provider is loaded and the store is not null, we render the Provider with the children
   return (
     <Provider store={store}>
       <div data-testid="redux-provider">

--- a/src/react/OptionalReduxProvider.test.jsx
+++ b/src/react/OptionalReduxProvider.test.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import OptionalReduxProvider from './OptionalReduxProvider'; // Adjust the import path as needed
+
+describe('OptionalReduxProvider', () => {
+  it('should handle error when react-redux import fails', async () => {
+    // Simulate the failed import of 'react-redux'
+    jest.mock('react-redux', () => {
+      throw new Error('Failed to load react-redux');
+    });
+
+    const mockStore = {}; // Mock store object
+    render(
+      <OptionalReduxProvider store={mockStore}>
+        <span>Test Children</span>
+      </OptionalReduxProvider>,
+    );
+
+    // Check that the children are still rendered even when react-redux fails to load
+    const childrenElement = await screen.findByText('Test Children');
+    expect(childrenElement).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
**Description:**

https://github.com/openedx/frontend-platform/issues/766

Per [this comment](https://github.com/openedx/frontend-platform/issues/766#issuecomment-2675466395), this PR reintroduces the changes to make the `redux` and `react-redux` peer dependencies optional.

Note: this PR is using a different approach to the dynamic import of `Provider` from `react-redux`. Instead of `React.lazy`, this approach uses a dynamic `import` within a `useEffect` inside `OptionalReduxProvider` (abstracted in a `useProvider` hook).

However, this alone does not prevent the need for ensuring consuming tests implement `await waitFor` or the equivalent to make existing tests pass (breaking change). To mitigate this, this PR's approach opts to use a synchronous `require()` instead of asynchronous `import()` when running `NODE_ENV='test'`.

The previous attempt at this contribution did suggest that it would be a breaking change by needing to add `await waitFor` throughout the `AppProvider.test.jsx`. In this approach, however, those `await waitFor` have been removed, suggesting it's no longer a breaking change (assuming we're OK with the approach).

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
