### PR TITLE
fix: manage if the BASE_URL does not have the protocol for themes urls

### DIFF
--- a/src/react/hooks/paragon/useParagonThemeCore.test.js
+++ b/src/react/hooks/paragon/useParagonThemeCore.test.js
@@ -51,8 +51,8 @@ describe('useParagonThemeCore', () => {
 
     const createdLinkTag = document.head.querySelector('link[data-paragon-theme-core="true"]');
     const createdBrandLinkTag = document.head.querySelector('link[data-brand-theme-core="true"]');
-    const defaultFallbackUrl = `${getConfig().BASE_URL}/${PARAGON_THEME.paragon.themeUrls.core.fileName}`;
-    const brandFallbackUrl = `${getConfig().BASE_URL}/${PARAGON_THEME.brand.themeUrls.core.fileName}`;
+    const defaultFallbackUrl = `//${getConfig().BASE_URL}/${PARAGON_THEME.paragon.themeUrls.core.fileName}`;
+    const brandFallbackUrl = `//${getConfig().BASE_URL}/${PARAGON_THEME.brand.themeUrls.core.fileName}`;
 
     act(() => { createdLinkTag.onerror(); createdBrandLinkTag.onerror(); });
 
@@ -61,8 +61,8 @@ describe('useParagonThemeCore', () => {
     expect(logInfo).toHaveBeenCalledTimes(2);
     expect(logInfo).toHaveBeenCalledWith(`Could not load core theme CSS from ${coreConfig.themeCore.urls.default}. Falling back to locally installed core theme CSS: ${defaultFallbackUrl}`);
     expect(logInfo).toHaveBeenCalledWith(`Could not load core theme CSS from ${coreConfig.themeCore.urls.brandOverride}. Falling back to locally installed core theme CSS: ${brandFallbackUrl}`);
-    expect(fallbackLinks[0].href).toBe(defaultFallbackUrl);
-    expect(fallbackLinks[1].href).toBe(brandFallbackUrl);
+    expect(fallbackLinks[0].href).toBe(`http:${defaultFallbackUrl}`);
+    expect(fallbackLinks[1].href).toBe(`http:${brandFallbackUrl}`);
   });
   it('should dispatch a log error if the fallback url is not loaded (either default or brandOverride)', () => {
     coreConfig.themeCore.urls.brandOverride = 'https://cdn.jsdelivr.net/npm/@edx/brand@2.0.0/dist/core.min.css';
@@ -70,8 +70,8 @@ describe('useParagonThemeCore', () => {
     renderHook(() => useParagonThemeCore(coreConfig));
     const createdLinkTag = document.head.querySelector('link[data-paragon-theme-core="true"]');
     const createdBrandLinkTag = document.head.querySelector('link[data-brand-theme-core="true"]');
-    const defaultFallbackUrl = `${getConfig().BASE_URL}/${PARAGON_THEME.paragon.themeUrls.core.fileName}`;
-    const brandFallbackUrl = `${getConfig().BASE_URL}/${PARAGON_THEME.brand.themeUrls.core.fileName}`;
+    const defaultFallbackUrl = `http://${getConfig().BASE_URL}/${PARAGON_THEME.paragon.themeUrls.core.fileName}`;
+    const brandFallbackUrl = `http://${getConfig().BASE_URL}/${PARAGON_THEME.brand.themeUrls.core.fileName}`;
 
     act(() => { createdLinkTag.onerror(); createdBrandLinkTag.onerror(); });
     const fallbackLinks = document.querySelectorAll('link');

--- a/src/react/hooks/paragon/useParagonThemeUrls.test.js
+++ b/src/react/hooks/paragon/useParagonThemeUrls.test.js
@@ -7,7 +7,7 @@ describe('useParagonThemeUrls', () => {
   beforeEach(() => { jest.resetAllMocks(); });
   it.each([
     [undefined, undefined],
-    [{}, { core: { urls: { default: 'localhost:8080/core.min.css', brandOverride: undefined } }, defaults: { light: 'light' }, variants: { light: { urls: { default: 'localhost:8080/light.min.css' } } } }],
+    [{}, { core: { urls: { default: '//localhost:8080/core.min.css', brandOverride: undefined } }, defaults: { light: 'light' }, variants: { light: { urls: { default: '//localhost:8080/light.min.css' } } } }],
   ])('handles when `config.PARAGON_THEME_URLS` is not present (%s)', (paragonThemeUrls, expectedURLConfig) => {
     mergeConfig({ PARAGON_THEME_URLS: paragonThemeUrls });
     const { result } = renderHook(() => useParagonThemeUrls());
@@ -122,7 +122,7 @@ describe('useParagonThemeUrls', () => {
         expect.objectContaining({
           core: {
             urls: {
-              default: 'localhost:8080/core.min.css',
+              default: '//localhost:8080/core.min.css',
               brandOverride: 'brand-core.css',
             },
           },
@@ -132,7 +132,7 @@ describe('useParagonThemeUrls', () => {
           variants: {
             light: {
               urls: {
-                default: 'localhost:8080/light.min.css',
+                default: '//localhost:8080/light.min.css',
               },
             },
           },

--- a/src/react/hooks/paragon/useParagonThemeVariants.test.js
+++ b/src/react/hooks/paragon/useParagonThemeVariants.test.js
@@ -51,10 +51,9 @@ describe('useParagonThemeVariants', () => {
     const currentThemeVariant = 'light';
 
     renderHook(() => useParagonThemeVariants({ themeVariants, currentThemeVariant, onComplete: themeOnComplete }));
-
     const themeLinks = document.head.querySelectorAll('link');
-    const paragonFallbackURL = `${getConfig().BASE_URL}/${PARAGON_THEME.paragon.themeUrls.variants.light.fileName}`;
-    const brandFallbackURL = `${getConfig().BASE_URL}/${PARAGON_THEME.brand.themeUrls.variants.light.fileName}`;
+    const paragonFallbackURL = `//${getConfig().BASE_URL}/${PARAGON_THEME.paragon.themeUrls.variants.light.fileName}`;
+    const brandFallbackURL = `//${getConfig().BASE_URL}/${PARAGON_THEME.brand.themeUrls.variants.light.fileName}`;
 
     act(() => { themeLinks.forEach((link) => link.onerror()); });
 
@@ -65,8 +64,8 @@ describe('useParagonThemeVariants', () => {
     const fallbackLinkTag = document.querySelectorAll('link');
 
     expect(fallbackLinkTag.length).toBe(2);
-    expect(fallbackLinkTag[0].href).toBe(paragonFallbackURL);
-    expect(fallbackLinkTag[1].href).toBe(brandFallbackURL);
+    expect(fallbackLinkTag[0].href).toBe(`http:${paragonFallbackURL}`);
+    expect(fallbackLinkTag[1].href).toBe(`http:${brandFallbackURL}`);
   });
 
   it('should dispatch a log error if the fallback url is not loaded (either default or brandOverride)', () => {
@@ -83,14 +82,14 @@ describe('useParagonThemeVariants', () => {
 
     renderHook(() => useParagonThemeVariants({ themeVariants, currentThemeVariant, onComplete: themeOnComplete }));
     const themeLinks = document.head.querySelectorAll('link');
-    const paragonFallbackURL = `${getConfig().BASE_URL}/${PARAGON_THEME.paragon.themeUrls.variants.light.fileName}`;
-    const brandFallbackURL = `${getConfig().BASE_URL}/${PARAGON_THEME.brand.themeUrls.variants.light.fileName}`;
+    const paragonFallbackURL = `//${getConfig().BASE_URL}/${PARAGON_THEME.paragon.themeUrls.variants.light.fileName}`;
+    const brandFallbackURL = `//${getConfig().BASE_URL}/${PARAGON_THEME.brand.themeUrls.variants.light.fileName}`;
 
     act(() => { themeLinks.forEach((link) => link.onerror()); });
 
     const fallbackLinks = document.querySelectorAll('link');
-    expect(fallbackLinks[0].href).toBe(paragonFallbackURL);
-    expect(fallbackLinks[1].href).toBe(brandFallbackURL);
+    expect(fallbackLinks[0].href).toBe(`http:${paragonFallbackURL}`);
+    expect(fallbackLinks[1].href).toBe(`http:${brandFallbackURL}`);
     act(() => { fallbackLinks.forEach((link) => link.onerror()); });
 
     expect(logInfo).toHaveBeenCalledTimes(2);

--- a/src/react/hooks/paragon/utils.js
+++ b/src/react/hooks/paragon/utils.js
@@ -18,7 +18,12 @@ export const removeExistingLinks = (existingLinks) => {
 */
 export const fallbackThemeUrl = (url) => {
   const baseUrl = getConfig().BASE_URL || window.location?.origin;
-  return `${baseUrl}${basename}${url}`;
+
+  // validates if the baseurl has the protocol to be interpreted correctly by the browser,
+  // if is not present add '//' to use Protocol-relative URL
+  const protocol = /^https?:\/\//.test(baseUrl) ? '' : '//';
+
+  return `${protocol}${baseUrl}${basename}${url}`;
 };
 
 export const isEmptyObject = (obj) => !obj || Object.keys(obj).length === 0;

--- a/src/react/hooks/paragon/utils.js
+++ b/src/react/hooks/paragon/utils.js
@@ -21,7 +21,7 @@ export const fallbackThemeUrl = (url) => {
 
   // validates if the baseurl has the protocol to be interpreted correctly by the browser,
   // if is not present add '//' to use Protocol-relative URL
-  const protocol = /^https?:\/\//.test(baseUrl) ? '' : '//';
+  const protocol = /^(https?:)?\/\//.test(baseUrl) ? '' : '//';
 
   return `${protocol}${baseUrl}${basename}${url}`;
 };

--- a/src/react/hooks/paragon/utils.test.js
+++ b/src/react/hooks/paragon/utils.test.js
@@ -1,0 +1,43 @@
+import { fallbackThemeUrl } from './utils';
+import { mergeConfig } from '../../../config';
+
+describe('fallbackThemeUrl', () => {
+  it('if should return a relative url if the BASE_URL does not provide the protocol', () => {
+    mergeConfig({
+      BASE_URL: 'example.com',
+    });
+
+    expect(fallbackThemeUrl('my.css')).toBe('//example.com/my.css');
+  });
+
+  it('if should return a relative url if the BASE_URL is a relative url', () => {
+    mergeConfig({
+      BASE_URL: '//example.com',
+    });
+    expect(fallbackThemeUrl('my.css')).toBe('//example.com/my.css');
+  });
+
+  it('if should return a full url if the BASE_URL provides the protocol', () => {
+    mergeConfig({
+      BASE_URL: 'http://example.com',
+    });
+    expect(fallbackThemeUrl('my.css')).toBe('http://example.com/my.css');
+
+    mergeConfig({
+      BASE_URL: 'https://example.com',
+    });
+    expect(fallbackThemeUrl('my.css')).toBe('https://example.com/my.css');
+  });
+
+  it('if should return a full url base on the window location if BASE_URL is not defined', () => {
+    mergeConfig({
+      BASE_URL: 'http://example.com',
+    });
+    expect(fallbackThemeUrl('my.css')).toBe('http://example.com/my.css');
+
+    mergeConfig({
+      BASE_URL: '',
+    });
+    expect(fallbackThemeUrl('my.css')).toBe('http://localhost/my.css');
+  });
+});


### PR DESCRIPTION
**Description:**

This PR manages the cases where the protocol is not present in the `BASE_URL` environment variable when is used for creating urls in the themes hook. 

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
