### PR TITLE
fix: create the brand fallback for {} PARAGON_THEME_URLS

### DIFF
--- a/src/react/hooks/paragon/useParagonThemeUrls.js
+++ b/src/react/hooks/paragon/useParagonThemeUrls.js
@@ -102,27 +102,42 @@ const useParagonThemeUrls = () => useMemo(() => {
 
   // If we don't have  the core default or any theme variants, use the PARAGON_THEME
   if (!coreCss.default || isEmptyObject(themeVariantsCss) || isEmptyObject(defaultThemeVariants)) {
-    const localCoreUrl = PARAGON_THEME.paragon?.themeUrls?.core;
-    const localThemeVariants = PARAGON_THEME.paragon?.themeUrls?.variants;
-    const localDefaultThemeVariants = PARAGON_THEME.paragon?.themeUrls?.defaults;
+    const localParagonCoreUrl = PARAGON_THEME?.paragon?.themeUrls?.core;
+    const localParagonThemeVariants = PARAGON_THEME?.paragon?.themeUrls?.variants;
+    const localParagonDefaultThemeVariants = PARAGON_THEME?.paragon?.themeUrls?.defaults;
 
-    if (isEmptyObject(localCoreUrl) || isEmptyObject(localThemeVariants)) {
+    const localBrandCoreUrl = PARAGON_THEME?.brand?.themeUrls?.core;
+    const localBrandThemeVariants = PARAGON_THEME?.brand?.themeUrls?.variants;
+    const localBrandDefaultThemeVariants = PARAGON_THEME?.brand?.themeUrls?.defaults;
+
+    if (isEmptyObject(localParagonCoreUrl) || isEmptyObject(localParagonThemeVariants)) {
       return undefined;
     }
     if (!coreCss.default) {
-      coreCss.default = fallbackThemeUrl(localCoreUrl?.fileName);
+      coreCss.default = fallbackThemeUrl(localParagonCoreUrl?.fileName);
+    }
+
+    if (!coreCss.brandOverride && localBrandCoreUrl) {
+      coreCss.brandOverride = fallbackThemeUrl(localBrandCoreUrl?.fileName);
     }
 
     if (isEmptyObject(themeVariantsCss)) {
-      Object.entries(localThemeVariants).forEach(([themeVariant, { fileName, ...rest }]) => {
+      Object.entries(localParagonThemeVariants).forEach(([themeVariant, { fileName, ...rest }]) => {
         themeVariantsCss[themeVariant] = {
           urls: { default: fallbackThemeUrl(fileName), ...rest.urls },
         };
       });
+
+      Object.entries(localBrandThemeVariants).forEach(([themeVariant, { fileName, ...rest }]) => {
+        themeVariantsCss[themeVariant] = {
+          urls: { brandOverride: fallbackThemeUrl(fileName), ...rest.urls, ...themeVariantsCss[themeVariant]?.urls },
+        };
+      });
     }
+
     return {
       core: { urls: coreCss },
-      defaults: defaultThemeVariants || localDefaultThemeVariants,
+      defaults: defaultThemeVariants || { ...localParagonDefaultThemeVariants, ...localBrandDefaultThemeVariants },
       variants: themeVariantsCss,
     };
   }

--- a/src/react/hooks/paragon/useParagonThemeUrls.test.js
+++ b/src/react/hooks/paragon/useParagonThemeUrls.test.js
@@ -3,11 +3,53 @@ import { renderHook } from '@testing-library/react';
 import useParagonThemeUrls from './useParagonThemeUrls';
 import { mergeConfig } from '../../../config';
 
+Object.defineProperty(global, 'PARAGON_THEME', {
+  value: {
+    paragon: {
+      version: '1.0.0',
+      themeUrls: {
+        core: {
+          fileName: 'local-core.min.css',
+        },
+        defaults: {
+          light: 'light',
+        },
+        variants: {
+          light: {
+            fileName: 'local-light.min.css',
+          },
+        },
+      },
+    },
+    brand: {
+      version: '1.0.0',
+      themeUrls: {
+        core: {
+          fileName: 'brand-local-core.min.css',
+        },
+        defaults: {
+          light: 'light',
+        },
+        variants: {
+          light: {
+            fileName: 'brand-local-light.min.css',
+          },
+        },
+      },
+    },
+  },
+  writable: true,
+});
+
 describe('useParagonThemeUrls', () => {
   beforeEach(() => { jest.resetAllMocks(); });
   it.each([
     [undefined, undefined],
-    [{}, { core: { urls: { default: '//localhost:8080/core.min.css', brandOverride: undefined } }, defaults: { light: 'light' }, variants: { light: { urls: { default: '//localhost:8080/light.min.css' } } } }],
+    [{}, {
+      core: { urls: { default: '//localhost:8080/local-core.min.css', brandOverride: '//localhost:8080/brand-local-core.min.css' } },
+      defaults: { light: 'light' },
+      variants: { light: { urls: { default: '//localhost:8080/local-light.min.css', brandOverride: '//localhost:8080/brand-local-light.min.css' } } },
+    }],
   ])('handles when `config.PARAGON_THEME_URLS` is not present (%s)', (paragonThemeUrls, expectedURLConfig) => {
     mergeConfig({ PARAGON_THEME_URLS: paragonThemeUrls });
     const { result } = renderHook(() => useParagonThemeUrls());
@@ -122,7 +164,7 @@ describe('useParagonThemeUrls', () => {
         expect.objectContaining({
           core: {
             urls: {
-              default: '//localhost:8080/core.min.css',
+              default: '//localhost:8080/local-core.min.css',
               brandOverride: 'brand-core.css',
             },
           },
@@ -132,7 +174,8 @@ describe('useParagonThemeUrls', () => {
           variants: {
             light: {
               urls: {
-                default: '//localhost:8080/light.min.css',
+                default: '//localhost:8080/local-light.min.css',
+                brandOverride: '//localhost:8080/brand-local-light.min.css',
               },
             },
           },
@@ -155,7 +198,7 @@ describe('useParagonThemeUrls', () => {
       };
       const originalParagonTheme = global.PARAGON_THEME;
       Object.defineProperty(global, 'PARAGON_THEME', {
-        value: 'mocked-theme',
+        value: undefined,
         writable: true,
       });
       mergeConfig(config);


### PR DESCRIPTION
**Description:**
If the brand package is installed with a compatible version of design tokens and define `PARAGON_THEMES_URLS={}` to use the local files, this one is not creating the corresponding urls - only the Paragon default ones. This PR aims to add the logic to permit the creation of those urls. 

![image](https://github.com/user-attachments/assets/eb63d238-75ed-4f36-8145-c70685ceae1a)

I added some improvements in the test file based on the comments of the original PR https://github.com/openedx/frontend-platform/pull/689#discussion_r1977840132

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
