### PR TITLE
chore: remove husky 🪓🐶

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "@testing-library/react": "16.2.0",
         "@testing-library/user-event": "14.6.1",
         "axios-mock-adapter": "^1.22.0",
-        "husky": "8.0.3",
         "jest-environment-jsdom": "29.7.0",
         "jest-localstorage-mock": "^2.4.26",
         "jsdoc": "^4.0.0",
@@ -12200,22 +12199,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyperdyperid": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@testing-library/react": "16.2.0",
     "@testing-library/user-event": "14.6.1",
     "axios-mock-adapter": "^1.22.0",
-    "husky": "8.0.3",
     "jest-environment-jsdom": "29.7.0",
     "jest-localstorage-mock": "^2.4.26",
     "jsdoc": "^4.0.0",


### PR DESCRIPTION
We remove husky, which is triggering pre-push git hooks, including running "npm lint". This is causing failures when building Docker images, because "npm clean-install --omit=dev" automatically triggers "npm prepare", which attemps to run "husky". But husky is not listed in the build dependencies, only in devDependencies. As a consequence, package installation is failing with the following error:

        14.13 > @edx/frontend-app-ora-grading@0.0.1 prepare
        14.13 > husky install
        14.13
        14.15 sh: 1: husky: not found

Similar to: https://github.com/openedx/frontend-app-learning/pull/1622
