### PR TITLE
fix: treat @openedx/frontend-build as an optional peerDep to avoid direct dep in consuming MFEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@edx/frontend-platform",
-  "version": "1.0.0-semantically-released",
+  "name": "@adamstankiewicz/openedx-frontend-platform",
+  "version": "8.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@edx/frontend-platform",
-      "version": "1.0.0-semantically-released",
+      "name": "@adamstankiewicz/openedx-frontend-platform",
+      "version": "8.3.6",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
@@ -64,6 +64,12 @@
         "react-redux": "^7.1.1 || ^8.1.1",
         "react-router-dom": "^6.0.0",
         "redux": "^4.0.4"
+      },
+      "peerDependenciesMeta": {
+        "@openedx/frontend-build": {
+          "optional": true,
+          "reason": "This package is only a peer dependency to ensure using a compatible version that provides env.config and PARAGON_THEME support. It is not needed at runtime."
+        }
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@adamstankiewicz/openedx-frontend-platform",
-  "version": "8.3.6",
+  "name": "@edx/frontend-platform",
+  "version": "1.0.0-semantically-released",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@adamstankiewicz/openedx-frontend-platform",
-      "version": "8.3.6",
+      "name": "@edx/frontend-platform",
+      "version": "1.0.0-semantically-released",
       "license": "AGPL-3.0",
       "dependencies": {
         "@cospired/i18n-iso-languages": "4.2.0",
@@ -68,7 +68,7 @@
       "peerDependenciesMeta": {
         "@openedx/frontend-build": {
           "optional": true,
-          "reason": "This package is only a peer dependency to ensure using a compatible version that provides env.config and PARAGON_THEME support. It is not needed at runtime."
+          "reason": "This package is only a peer dependency to ensure using a compatible version that provides env.config and PARAGON_THEME support. It is not needed at runtime, and may be omitted with `--omit=optional`."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@edx/frontend-platform",
-  "version": "1.0.0-semantically-released",
+  "name": "@adamstankiewicz/openedx-frontend-platform",
+  "version": "8.3.6",
   "description": "Foundational application framework for Open edX micro-frontend applications.",
   "main": "index.js",
   "publishConfig": {
@@ -84,5 +84,11 @@
     "react-redux": "^7.1.1 || ^8.1.1",
     "react-router-dom": "^6.0.0",
     "redux": "^4.0.4"
+  },
+  "peerDependenciesMeta": {
+    "@openedx/frontend-build": {
+      "optional": true,
+      "reason": "This package is only a peer dependency to ensure using a compatible version that provides env.config and PARAGON_THEME support. It is not needed at runtime, and may be omitted with `--omit=optional`."
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   "peerDependenciesMeta": {
     "@openedx/frontend-build": {
       "optional": true,
-      "reason": "This package is only a peer dependency to ensure using a compatible version that provides env.config and PARAGON_THEME support. It is not needed at runtime, and may be omitted with `--omit=optional`."
+      "reason": "This package is only a peer dependency to ensure using a minimum compatible version that provides env.config and PARAGON_THEME support. It is not needed at runtime, and may be omitted with `--omit=optional`."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@adamstankiewicz/openedx-frontend-platform",
-  "version": "8.3.6",
+  "name": "@edx/frontend-platform",
+  "version": "1.0.0-semantically-released",
   "description": "Foundational application framework for Open edX micro-frontend applications.",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
**Related discussions:**
* https://github.com/openedx/frontend-platform/pull/787
* https://github.com/openedx/open-edx-proposals/pull/615

**Corresponding PR:**
* https://github.com/openedx/frontend-app-communications/pull/221

**Description:**

Demonstrates treating `@openedx/frontend-build` as an **optional** peer dependency within `@edx/frontend-platform`, such that consuming MFEs no longer considers `@openedx/frontend-build` as a direct dependency, via:

```json
{
  "peerDependenciesMeta": {
      "@openedx/frontend-build": {
        "optional": true
      }
    }
}
```

From @brian-smith-tcril [here](https://github.com/openedx/frontend-platform/pull/787#issuecomment-2775706607):

> As for `frontend-build` specifically, the fact that it is currently in `frontend-platform`'s `peerDependencies` means that MFEs adding `frontend-platform` as a direct dependency end up with a non-dev dependency on `frontend-build`. In `frontend-app-communications` for example, `@testing-library/react` is in the package lock [with `"dev": true`](https://github.com/openedx/frontend-app-communications/blob/1cd02a9dfb85ddc9e594b6e4b490f33e26a7cac1/package-lock.json#L4895), while `frontend-build` (which is in `package.json` [as a dev dep](https://github.com/openedx/frontend-app-communications/blob/1cd02a9dfb85ddc9e594b6e4b490f33e26a7cac1/package.json#L70)) is [not in `package-lock.json` as dev](https://github.com/openedx/frontend-app-communications/blob/1cd02a9dfb85ddc9e594b6e4b490f33e26a7cac1/package-lock.json#L3707).

This indeed does pose a problem for consuming MFEs as `@openedx/frontend-build` should not be considered as a direct `dependencies` when the MFE itself installs `@openedx/frontend-build` as a `devDependencies`.

Why might this optional peer dependency might work?

> Npm will not automatically install optional peer dependencies ([docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependenciesmeta))

Testing the optional peer dependency approach with frontend-app-communications ([PR](https://github.com/openedx/frontend-app-communications/pull/221)), `@openedx/frontend-build` is no longer treated a direct dependency, but instead receives `devOptional: true` in `package-lock.json` ([source](https://github.com/adamstankiewicz/openedx-frontend-app-communications/blob/72bdd540aa0c4d4caf9cc171cb31be8f83228ccd/package-lock.json#L3767)).

While `npm ci --omit=dev` doesn't omit `@openedx/frontend-build` from being installed for the MFE, `npm ci --omit=dev --omit=optional` would.

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
