### PR TITLE
fix: support not setting default in variant when using PARAGON_THEME_URLS

### DIFF
--- a/src/react/hooks/paragon/useParagonThemeUrls.js
+++ b/src/react/hooks/paragon/useParagonThemeUrls.js
@@ -56,7 +56,6 @@ const useParagonThemeUrls = () => useMemo(() => {
   if (!paragonThemeUrls) {
     return undefined;
   }
-
   const paragonCoreCssUrl = typeof paragonThemeUrls?.core?.urls === 'object' ? paragonThemeUrls.core.urls.default : paragonThemeUrls?.core?.url;
   const brandCoreCssUrl = typeof paragonThemeUrls?.core?.urls === 'object' ? paragonThemeUrls.core.urls.brandOverride : undefined;
   const defaultThemeVariants = paragonThemeUrls.defaults;
@@ -117,23 +116,24 @@ const useParagonThemeUrls = () => useMemo(() => {
       coreCss.default = fallbackThemeUrl(localParagonCoreUrl?.fileName);
     }
 
-    if (!coreCss.brandOverride && localBrandCoreUrl) {
+    if (!coreCss.brandOverride && !isEmptyObject(localBrandCoreUrl)) {
       coreCss.brandOverride = fallbackThemeUrl(localBrandCoreUrl?.fileName);
     }
 
-    if (isEmptyObject(themeVariantsCss)) {
-      Object.entries(localParagonThemeVariants).forEach(([themeVariant, { fileName, ...rest }]) => {
+    Object.entries(localParagonThemeVariants).forEach(([themeVariant, { fileName, ...rest }]) => {
+      if (!themeVariantsCss[themeVariant]?.urls?.default) {
         themeVariantsCss[themeVariant] = {
-          urls: { default: fallbackThemeUrl(fileName), ...rest.urls },
+          urls: { ...themeVariantsCss[themeVariant]?.urls, default: fallbackThemeUrl(fileName), ...rest.urls },
         };
-      });
-
-      Object.entries(localBrandThemeVariants).forEach(([themeVariant, { fileName, ...rest }]) => {
+      }
+    });
+    Object.entries(localBrandThemeVariants).forEach(([themeVariant, { fileName, ...rest }]) => {
+      if (!themeVariantsCss[themeVariant]?.urls?.brandOverride) {
         themeVariantsCss[themeVariant] = {
-          urls: { brandOverride: fallbackThemeUrl(fileName), ...rest.urls, ...themeVariantsCss[themeVariant]?.urls },
+          urls: { ...themeVariantsCss[themeVariant]?.urls, brandOverride: fallbackThemeUrl(fileName), ...rest.urls },
         };
-      });
-    }
+      }
+    });
 
     return {
       core: { urls: coreCss },

--- a/src/react/hooks/paragon/useParagonThemeUrls.test.js
+++ b/src/react/hooks/paragon/useParagonThemeUrls.test.js
@@ -276,3 +276,48 @@ describe('useParagonThemeUrls', () => {
     });
   });
 });
+
+it('returns expected object when only brand override URLs are present, fallback to PARAGON_THEME', () => {
+  const config = {
+    PARAGON_THEME_URLS: {
+      core: {
+        urls: {
+          brandOverride: 'https://www.example.com/example-brand-core.css',
+        },
+      },
+      defaults: {
+        light: 'light',
+      },
+      variants: {
+        light: {
+          urls: {
+            brandOverride: 'https://www.example.com/example-brand-light.css',
+          },
+        },
+      },
+    },
+  };
+  mergeConfig(config);
+  const { result } = renderHook(() => useParagonThemeUrls());
+  expect(result.current).toEqual(
+    expect.objectContaining({
+      core: {
+        urls: {
+          default: '//localhost:8080/local-core.min.css',
+          brandOverride: 'https://www.example.com/example-brand-core.css',
+        },
+      },
+      defaults: {
+        light: 'light',
+      },
+      variants: {
+        light: {
+          urls: {
+            default: '//localhost:8080/local-light.min.css',
+            brandOverride: 'https://www.example.com/example-brand-light.css',
+          },
+        },
+      },
+    }),
+  );
+});

--- a/src/react/hooks/paragon/useParagonThemeUrls.test.js
+++ b/src/react/hooks/paragon/useParagonThemeUrls.test.js
@@ -274,50 +274,49 @@ describe('useParagonThemeUrls', () => {
         }),
       );
     });
+    it('returns expected object when only brand override URLs are present, fallback to PARAGON_THEME', () => {
+      const config = {
+        PARAGON_THEME_URLS: {
+          core: {
+            urls: {
+              brandOverride: 'https://www.example.com/example-brand-core.css',
+            },
+          },
+          defaults: {
+            light: 'light',
+          },
+          variants: {
+            light: {
+              urls: {
+                brandOverride: 'https://www.example.com/example-brand-light.css',
+              },
+            },
+          },
+        },
+      };
+      mergeConfig(config);
+      const { result } = renderHook(() => useParagonThemeUrls());
+      expect(result.current).toEqual(
+        expect.objectContaining({
+          core: {
+            urls: {
+              default: '//localhost:8080/local-core.min.css',
+              brandOverride: 'https://www.example.com/example-brand-core.css',
+            },
+          },
+          defaults: {
+            light: 'light',
+          },
+          variants: {
+            light: {
+              urls: {
+                default: '//localhost:8080/local-light.min.css',
+                brandOverride: 'https://www.example.com/example-brand-light.css',
+              },
+            },
+          },
+        }),
+      );
+    });
   });
-});
-
-it('returns expected object when only brand override URLs are present, fallback to PARAGON_THEME', () => {
-  const config = {
-    PARAGON_THEME_URLS: {
-      core: {
-        urls: {
-          brandOverride: 'https://www.example.com/example-brand-core.css',
-        },
-      },
-      defaults: {
-        light: 'light',
-      },
-      variants: {
-        light: {
-          urls: {
-            brandOverride: 'https://www.example.com/example-brand-light.css',
-          },
-        },
-      },
-    },
-  };
-  mergeConfig(config);
-  const { result } = renderHook(() => useParagonThemeUrls());
-  expect(result.current).toEqual(
-    expect.objectContaining({
-      core: {
-        urls: {
-          default: '//localhost:8080/local-core.min.css',
-          brandOverride: 'https://www.example.com/example-brand-core.css',
-        },
-      },
-      defaults: {
-        light: 'light',
-      },
-      variants: {
-        light: {
-          urls: {
-            default: '//localhost:8080/local-light.min.css',
-            brandOverride: 'https://www.example.com/example-brand-light.css',
-          },
-        },
-      },
-    }),
-  );
 });


### PR DESCRIPTION
**Description:**

This PR aims to allow the creation of URLs with only `brandOverride` definition.

Solving the following use case https://github.com/openedx/frontend-platform/issues/808

**Merge checklist:**

- [ ] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [ ] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [ ] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
