### PR TITLE
docs: move reference-style link above module tag

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -118,10 +118,10 @@
  * });
  * ```
  *
- * @module Config
- *
  * [1]: https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/mfe_config_api/docs/decisions/0001-mfe-config-api.rst
- */
+ *
+ * @module Config
+ * */
 
 import { APP_CONFIG_INITIALIZED, CONFIG_CHANGED } from './constants';
 


### PR DESCRIPTION
**Description:**

Fix rendering issues of [reference-style](https://www.markdownguide.org/basic-syntax/#reference-style-links) markdown link to ADR in the Config module docs.

Resolves #817 .

I tested this change locally by running `npm run docs` and then opening `docs/api/@edx/frontend-platform/1.0.0-semantically-released/index.html` in Chrome. The Config link on the index page was fixed and the link on the Config page (`module-Config.html`) rendered correctly.

**Merge checklist:**

- [x] Consider running your code modifications in the included example app within `frontend-platform`. This can be done by running `npm start` and opening http://localhost:8080.
- [x] Consider testing your code modifications in another local micro-frontend using local aliases configured via [the `module.config.js` file in `frontend-build`](https://github.com/openedx/frontend-build#local-module-configuration-for-webpack).
- [x] Verify your commit title/body conforms to the conventional commits format (e.g., `fix`, `feat`) and is appropriate for your code change. Consider whether your code is a breaking change, and modify your commit accordingly.

**Post merge:**

- [ ] After the build finishes for the merged commit, verify the new release has been pushed to [NPM](https://www.npmjs.com/package/@edx/frontend-platform).
